### PR TITLE
feat: centralize constants and add timeout support to apply command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,25 +94,16 @@ agentinit mcp --install <name>     # Install specific MCP
 
 ### `agentinit verify_mcp`
 
-Verify MCP server installations and list their capabilities.
-
-```bash
-agentinit verify_mcp --all              # Verify all configured MCP servers
-agentinit verify_mcp --mcp-name <name>  # Verify specific MCP server
-```
+Verify MCP server installations and get their tools with token usage.
 
 **Examples:**
 ```bash
 # Verify all MCPs in project
 agentinit verify_mcp --all
-
-# Verify specific server
-agentinit verify_mcp --mcp-name everything
-
-# Test MCP configuration directly
+# Verify STDIO server
 agentinit verify_mcp --mcp-stdio everything "npx -y @modelcontextprotocol/server-everything"
-
-agentinit verify_mcp --mcp-http
+# Verify HTTP server
+agentinit verify_mcp --mcp-http notion_api "https://mcp.notion.com/mcp"  --timeout 30000
 ```
 
 Shows connection status, response time, and available tools/resources/prompts for each MCP server.
@@ -181,7 +172,13 @@ This generates `.agentinit/agentinit.toml` with your MCP configurations.
 - `--header "KEY:VALUE"` - Adds custom headers in KEY:VALUE format (can be used multiple times)
 - Both flags can be combined for APIs requiring multiple authentication methods
 
-**MCP Verification**: Use the `--verify-mcp` flag to test MCP servers immediately after configuration. This ensures servers are reachable and shows their available tools, resources, and prompts.
+**MCP Verification**: Use the `--verify-mcp` flag to test MCP servers immediately after configuration. This ensures servers are reachable and shows their available tools, resources, and prompts. Use `--timeout <ms>` to set a custom connection timeout (default: 30000ms).
+
+```bash
+# Verify with custom timeout
+npx agentinit apply --verify-mcp --timeout 30000 \
+  --mcp-stdio chrome-mcp "bunx -y chrome-devtools-mcp@latest"
+```
 
 #### Rules Configuration
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -35,8 +35,7 @@ interface ApplyResult {
 function colorizeTokenCount(tokenCount: number): string {
   if (tokenCount <= TOKEN_COUNT_THRESHOLDS.LOW) return green(tokenCount.toString());
   if (tokenCount <= TOKEN_COUNT_THRESHOLDS.MEDIUM) return yellow(tokenCount.toString());
-  if (tokenCount <= 30000) return red(tokenCount.toString()); // Light red approximated with red
-  return red(tokenCount.toString()); // Red for >30k
+  return red(tokenCount.toString());
 }
 
 function colorizeTokenDiff(diff: number): string {
@@ -70,7 +69,7 @@ export async function applyCommand(args: string[]): Promise<void> {
   const timeoutIndex = args.findIndex(arg => arg === '--timeout');
   const timeoutArg = timeoutIndex >= 0 && timeoutIndex + 1 < args.length ? args[timeoutIndex + 1] : null;
   const parsedTimeout = timeoutArg ? parseInt(timeoutArg, 10) : NaN;
-  const timeout = timeoutArg && !Number.isNaN(parsedTimeout) && Number.isFinite(parsedTimeout) ? parsedTimeout : undefined;
+  const timeout = timeoutArg && Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : undefined;
   
   if (!hasMcpArgs && !hasRulesArgs) {
     logger.info('Usage: agentinit apply [options]');

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -387,7 +387,17 @@ export async function applyCommand(args: string[]): Promise<void> {
         if (server.type === 'stdio' && server.command) {
           logger.info(`    Command: ${server.command} ${server.args?.join(' ') || ''}`);
         } else if (server.url) {
-          logger.info(`    URL: ${server.url}`);
+          let sanitizedUrl: string;
+          try {
+            const parsedUrl = new URL(server.url);
+            parsedUrl.username = '';
+            parsedUrl.password = '';
+            parsedUrl.search = '';
+            sanitizedUrl = parsedUrl.toString();
+          } catch {
+            sanitizedUrl = server.url.split('?')[0] || 'invalid-url';
+          }
+          logger.info(`    URL: ${sanitizedUrl}`);
         }
       });
     }

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -2,6 +2,7 @@ import ora from 'ora';
 import { green, yellow, red, cyan } from 'kleur/colors';
 import { logger } from '../utils/logger.js';
 import { MCPParser, MCPParseError } from '../core/mcpParser.js';
+import { TOKEN_COUNT_THRESHOLDS, DEFAULT_CONNECTION_TIMEOUT_MS } from '../constants/index.js';
 import { RulesParser, RulesParseError } from '../core/rulesParser.js';
 import { TOMLGenerator } from '../core/tomlGenerator.js';
 import { readFileIfExists, writeFile, getAgentInitTomlPath } from '../utils/fs.js';
@@ -32,8 +33,8 @@ interface ApplyResult {
 
 // Color utility functions for token display
 function colorizeTokenCount(tokenCount: number): string {
-  if (tokenCount <= 5000) return green(tokenCount.toString());
-  if (tokenCount <= 15000) return yellow(tokenCount.toString());
+  if (tokenCount <= TOKEN_COUNT_THRESHOLDS.LOW) return green(tokenCount.toString());
+  if (tokenCount <= TOKEN_COUNT_THRESHOLDS.MEDIUM) return yellow(tokenCount.toString());
   if (tokenCount <= 30000) return red(tokenCount.toString()); // Light red approximated with red
   return red(tokenCount.toString()); // Red for >30k
 }
@@ -65,6 +66,12 @@ export async function applyCommand(args: string[]): Promise<void> {
   // Check if --verify-mcp flag is specified
   const verifyMcp = args.includes('--verify-mcp');
   
+  // Parse timeout argument
+  const timeoutIndex = args.findIndex(arg => arg === '--timeout');
+  const timeoutArg = timeoutIndex >= 0 && timeoutIndex + 1 < args.length ? args[timeoutIndex + 1] : null;
+  const parsedTimeout = timeoutArg ? parseInt(timeoutArg, 10) : NaN;
+  const timeout = timeoutArg && !Number.isNaN(parsedTimeout) && Number.isFinite(parsedTimeout) ? parsedTimeout : undefined;
+  
   if (!hasMcpArgs && !hasRulesArgs) {
     logger.info('Usage: agentinit apply [options]');
     logger.info('');
@@ -74,6 +81,7 @@ export async function applyCommand(args: string[]): Promise<void> {
     logger.info('  --global            Apply configuration globally (requires --agent)');
     logger.info('                      If not specified, auto-detects agents in the project');
     logger.info('  --verify-mcp        Verify MCP servers after configuration');
+    logger.info(`  --timeout <ms>      Connection timeout in milliseconds for MCP verification (default: ${DEFAULT_CONNECTION_TIMEOUT_MS})`);
     logger.info('');
     logger.info('Rules Configuration Options:');
     logger.info('  --rules <templates>     Apply rule templates (comma-separated)');
@@ -134,9 +142,9 @@ export async function applyCommand(args: string[]): Promise<void> {
     // Parse the MCP arguments (filter out --client, --agent, --global and rules args)
     const mcpArgs = args.filter((arg, index) => {
       // Filter out non-MCP arguments
-      if (arg === '--client' || arg === '--agent' || arg === '--global' || arg === '--verify-mcp') return false;
+      if (arg === '--client' || arg === '--agent' || arg === '--global' || arg === '--verify-mcp' || arg === '--timeout') return false;
       if (arg === '--rules' || arg === '--rule-raw' || arg === '--rules-file' || arg === '--rules-remote') return false;
-      if (index > 0 && (args[index - 1] === '--client' || args[index - 1] === '--agent')) return false;
+      if (index > 0 && (args[index - 1] === '--client' || args[index - 1] === '--agent' || args[index - 1] === '--timeout')) return false;
       if (index > 0 && (args[index - 1] === '--rules' || args[index - 1] === '--rule-raw' || args[index - 1] === '--rules-file' || args[index - 1] === '--rules-remote')) return false;
       return true;
     });
@@ -334,8 +342,8 @@ export async function applyCommand(args: string[]): Promise<void> {
       const verifySpinner = ora(`Verifying ${mcpParsed.servers.length} MCP server(s)...`).start();
       
       try {
-        const verifier = new MCPVerifier();
-        const verificationResults = await verifier.verifyServers(mcpParsed.servers);
+        const verifier = new MCPVerifier(timeout);
+        const verificationResults = await verifier.verifyServers(mcpParsed.servers, timeout);
         
         const successCount = verificationResults.filter(r => r.status === 'success').length;
         const errorCount = verificationResults.filter(r => r.status === 'error').length;

--- a/src/commands/verifyMcp.ts
+++ b/src/commands/verifyMcp.ts
@@ -1,6 +1,7 @@
 import ora from 'ora';
 import { logger } from '../utils/logger.js';
 import { MCPVerifier } from '../core/mcpClient.js';
+import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../constants/index.js';
 import { MCPParser, MCPParseError } from '../core/mcpParser.js';
 import { AgentManager } from '../core/agentManager.js';
 import type { MCPServerConfig } from '../types/index.js';
@@ -45,7 +46,7 @@ export async function verifyMcpCommand(args: string[]): Promise<void> {
     logger.info('Verify existing configurations:');
     logger.info('  --mcp-name <name>    Verify specific MCP server by name');
     logger.info('  --all                Verify all configured MCP servers');
-    logger.info('  --timeout <ms>       Connection timeout in milliseconds (default: 10000)');
+    logger.info(`  --timeout <ms>       Connection timeout in milliseconds (default: ${DEFAULT_CONNECTION_TIMEOUT_MS})`);
     logger.info('');
     logger.info('Verify direct MCP configuration:');
     logger.info('  --mcp-stdio <name> <command>     Verify STDIO MCP server');

--- a/src/commands/verifyMcp.ts
+++ b/src/commands/verifyMcp.ts
@@ -24,7 +24,7 @@ export async function verifyMcpCommand(args: string[]): Promise<void> {
   const timeoutIndex = args.findIndex(arg => arg === '--timeout');
   const timeoutArg = timeoutIndex >= 0 && timeoutIndex + 1 < args.length ? args[timeoutIndex + 1] : null;
   const parsedTimeout = timeoutArg ? parseInt(timeoutArg, 10) : NaN;
-  const timeout = timeoutArg && !Number.isNaN(parsedTimeout) && Number.isFinite(parsedTimeout) ? parsedTimeout : undefined;
+  const timeout = timeoutArg && Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : undefined;
   
   // Check if MCP configuration arguments are present
   const hasMcpArgs = args.some(arg => arg.startsWith('--mcp-'));

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export { DEFAULT_CONNECTION_TIMEOUT_MS, MCP_VERIFIER_CONFIG, TimeoutError } from './mcp.js';
+export { TOKEN_COUNT_THRESHOLDS, type TokenCountThreshold } from './tokens.js';

--- a/src/constants/mcp.ts
+++ b/src/constants/mcp.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
+
+export const MCP_VERIFIER_CONFIG = {
+  name: "agentinit-verifier",
+  version: "1.0.0"
+} as const;
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}

--- a/src/constants/mcp.ts
+++ b/src/constants/mcp.ts
@@ -1,8 +1,25 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
 export const DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
+
+// Dynamic version from package.json
+function getPackageVersion(): string {
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const packageJsonPath = join(__dirname, '../../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version || '1.0.0';
+  } catch {
+    return '1.0.0';
+  }
+}
 
 export const MCP_VERIFIER_CONFIG = {
   name: "agentinit-verifier",
-  version: "1.0.0"
+  version: getPackageVersion()
 } as const;
 
 export class TimeoutError extends Error {

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,0 +1,6 @@
+export const TOKEN_COUNT_THRESHOLDS = {
+  LOW: 5000,
+  MEDIUM: 15000
+} as const;
+
+export type TokenCountThreshold = typeof TOKEN_COUNT_THRESHOLDS[keyof typeof TOKEN_COUNT_THRESHOLDS];

--- a/src/core/mcpClient.ts
+++ b/src/core/mcpClient.ts
@@ -5,6 +5,7 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { countTokens } from 'contextcalc';
 import { green, yellow, red } from 'kleur/colors';
 import { MCPServerType } from '../types/index.js';
+import { DEFAULT_CONNECTION_TIMEOUT_MS, MCP_VERIFIER_CONFIG, TimeoutError, TOKEN_COUNT_THRESHOLDS } from '../constants/index.js';
 import type { 
   MCPServerConfig, 
   MCPVerificationResult, 
@@ -21,17 +22,11 @@ export class MCPVerificationError extends Error {
   }
 }
 
-export class TimeoutError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'TimeoutError';
-  }
-}
 
 export class MCPVerifier {
   private defaultTimeout: number;
 
-  constructor(defaultTimeout: number = 10000) {
+  constructor(defaultTimeout: number = DEFAULT_CONNECTION_TIMEOUT_MS) {
     this.defaultTimeout = defaultTimeout;
   }
 
@@ -39,8 +34,8 @@ export class MCPVerifier {
    * Color utility function for token display
    */
   private colorizeTokenCount(tokenCount: number): string {
-    if (tokenCount <= 5000) return green(tokenCount.toString());
-    if (tokenCount <= 15000) return yellow(tokenCount.toString());
+    if (tokenCount <= TOKEN_COUNT_THRESHOLDS.LOW) return green(tokenCount.toString());
+    if (tokenCount <= TOKEN_COUNT_THRESHOLDS.MEDIUM) return yellow(tokenCount.toString());
     return red(tokenCount.toString());
   }
 
@@ -92,8 +87,8 @@ export class MCPVerifier {
       
       // Create the MCP client
       client = new Client({
-        name: "agentinit-verifier",
-        version: "1.0.0"
+        name: MCP_VERIFIER_CONFIG.name,
+        version: MCP_VERIFIER_CONFIG.version
       });
 
       // Set up timeout promise that properly cancels resources

--- a/src/core/rulesParser.ts
+++ b/src/core/rulesParser.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { fileExists } from '../utils/fs.js';
 import { RulesTemplateLoader } from './rulesTemplateLoader.js';
 import type { RulesConfig, AppliedRules, RemoteRulesOptions } from '../types/rules.js';
+import { DEFAULT_CONNECTION_TIMEOUT_MS } from '../constants/index.js';
 
 export class RulesParseError extends Error {
   constructor(message: string) {
@@ -191,7 +192,7 @@ export class RulesParser {
       }
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), options.timeout || 10000);
+      const timeoutId = setTimeout(() => controller.abort(), options.timeout || DEFAULT_CONNECTION_TIMEOUT_MS);
 
       const response = await fetch(options.url, {
         headers,

--- a/src/core/rulesParser.ts
+++ b/src/core/rulesParser.ts
@@ -192,14 +192,17 @@ export class RulesParser {
       }
 
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), options.timeout || DEFAULT_CONNECTION_TIMEOUT_MS);
-
-      const response = await fetch(options.url, {
-        headers,
-        signal: controller.signal
-      });
-
-      clearTimeout(timeoutId);
+      const timeoutMs = options.timeout ?? DEFAULT_CONNECTION_TIMEOUT_MS;
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+      let response: any;
+      try {
+        response = await fetch(options.url, {
+          headers,
+          signal: controller.signal
+        });
+      } finally {
+        clearTimeout(timeoutId);
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -215,9 +218,9 @@ export class RulesParser {
         // Treat as plain text
         return content
           .split('\n')
-          .map(line => line.trim())
-          .filter(line => line && !line.startsWith('#'))
-          .map(line => line.replace(/^[-*]\s*/, ''));
+          .map((line: string) => line.trim())
+          .filter((line: string) => line && !line.startsWith('#'))
+          .map((line: string) => line.replace(/^[-*]\s*/, ''));
       }
     } catch (error) {
       throw new RulesParseError(`Failed to fetch remote rules from ${options.url}: ${error instanceof Error ? error.message : 'Unknown error'}`);


### PR DESCRIPTION
- Create centralized constants structure in src/constants/
  - MCP-related constants (DEFAULT_CONNECTION_TIMEOUT_MS=30000, TimeoutError)
  - Token threshold constants (LOW=5000, MEDIUM=15000)
- Add --timeout flag support to apply command's --verify-mcp feature
- Update all hardcoded timeouts to use centralized constants
- Add timeout documentation to README with examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable connection timeout for MCP verification via a CLI flag (default 30,000 ms) and standardized token-count thresholds; timeout exposed in help and used across verification flows.
  - Added public exports for timeout, token thresholds, and a TimeoutError to unify error/reporting behavior.

- **Documentation**
  - README updated to emphasize token-based usage, timeout configuration, and added STDIO/HTTP/apply examples.

- **Bug Fixes**
  - Stricter validation of timeout inputs and improved timeout/cleanup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->