### PR TITLE
feat: add library API for programmatic MCP verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ tests/**/*.db
 tests/**/*.sqlite
 tests/**/*.sqlite3
 
+# Compiled TypeScript test files
+tests/**/*.js
+tests/**/*.d.ts
+tests/**/*.js.map
+tests/**/*.d.ts.map
+
 # Optional npm cache directory
 .npm
 

--- a/examples/library-usage.ts
+++ b/examples/library-usage.ts
@@ -1,0 +1,55 @@
+/**
+ * Example: Using AgentInit as a Library
+ *
+ * This example demonstrates how to use agentinit as a library
+ * to verify MCP servers programmatically.
+ */
+
+import { MCPVerifier, MCPServerType, type MCPServerConfig } from '../src/lib/index.js';
+
+async function main() {
+  console.log('🔍 AgentInit Library Example\n');
+
+  // Create a verifier instance with 10 second timeout
+  const verifier = new MCPVerifier(10000);
+
+  // Define a simple STDIO MCP server config
+  const server: MCPServerConfig = {
+    name: 'everything',
+    type: MCPServerType.STDIO,
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-everything']
+  };
+
+  console.log(`Verifying MCP server: ${server.name}...\n`);
+
+  try {
+    // Verify the server
+    const result = await verifier.verifyServer(server);
+
+    // Check the result
+    if (result.status === 'success') {
+      console.log(`✅ Success!`);
+      console.log(`Connection time: ${result.connectionTime}ms`);
+      console.log(`Tools found: ${result.capabilities?.tools.length || 0}`);
+      console.log(`Total tokens: ${result.capabilities?.totalToolTokens || 0}\n`);
+
+      // List the first 5 tools
+      if (result.capabilities?.tools) {
+        console.log('Sample tools:');
+        result.capabilities.tools.slice(0, 5).forEach(tool => {
+          const tokens = result.capabilities?.toolTokenCounts?.get(tool.name) || 0;
+          console.log(`  • ${tool.name} (${tokens} tokens)`);
+        });
+      }
+    } else {
+      console.error(`❌ Verification failed: ${result.status}`);
+      console.error(`Error: ${result.error}`);
+    }
+  } catch (error) {
+    console.error('Error verifying server:', error);
+  }
+}
+
+// Run the example
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && cp -r src/templates dist/ && bun build dist/cli.js --outfile dist/cli-bundled.js --target node --external tiktoken && mv dist/cli-bundled.js dist/cli.js",
+    "build": "npx tsc -p tsconfig.build.json && cp -r src/templates dist/ && bun build dist/cli.js --outfile dist/cli-bundled.js --target node --external tiktoken && mv dist/cli-bundled.js dist/cli.js",
     "dev": "bun run src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,34 @@
 {
   "name": "agentinit",
   "version": "1.4.1",
-  "description": "A CLI tool for managing and configuring AI coding agents",
+  "description": "CLI tool and library for managing AI coding agents and verifying MCP servers",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "bin": {
-    "agentinit": "dist/index.js"
+    "agentinit": "dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./verifier": {
+      "import": "./dist/lib/verifier/index.js",
+      "types": "./dist/lib/verifier/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/lib/types/index.js",
+      "types": "./dist/lib/types/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/lib/utils/index.js",
+      "types": "./dist/lib/utils/index.d.ts"
+    }
   },
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target node --external tiktoken && cp -r src/templates dist/",
-    "dev": "bun run src/index.ts",
+    "build": "tsc -p tsconfig.build.json && cp -r src/templates dist/ && bun build dist/cli.js --outfile dist/cli-bundled.js --target node --external tiktoken && mv dist/cli-bundled.js dist/cli.js",
+    "dev": "bun run src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test_all": "vitest run && tsc --noEmit",
@@ -22,8 +41,13 @@
     "ai",
     "agents",
     "cli",
+    "library",
+    "sdk",
+    "mcp",
+    "model-context-protocol",
     "configuration",
-    "automation"
+    "automation",
+    "verification"
   ],
   "author": "AgentInit Team",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,12 +18,10 @@ program
   .command('apply')
   .description('Apply configurations (MCP servers, etc.)')
   .allowUnknownOption(true)
-  .action((...args) => {
-    // Extract raw arguments, excluding the command name
-    const rawArgs = process.argv.slice(2);
-    const applyIndex = rawArgs.indexOf('apply');
-    const configArgs = applyIndex >= 0 ? rawArgs.slice(applyIndex + 1) : [];
-    applyCommand(configArgs);
+  .action((options, command) => {
+    // Let Commander parse the arguments properly
+    const parsed = command.parseOptions(command.parent.rawArgs.slice(3));
+    applyCommand(parsed.unknown);
   });
 
 program
@@ -50,12 +48,10 @@ program
   .command('verify_mcp')
   .description('Verify MCP server installations and list their capabilities')
   .allowUnknownOption(true)
-  .action((...args) => {
-    // Extract raw arguments, excluding the command name
-    const rawArgs = process.argv.slice(2);
-    const verifyIndex = rawArgs.indexOf('verify_mcp');
-    const commandArgs = verifyIndex >= 0 ? rawArgs.slice(verifyIndex + 1) : [];
-    verifyMcpCommand(commandArgs);
+  .action((options, command) => {
+    // Let Commander parse the arguments properly
+    const parsed = command.parseOptions(command.parent.rawArgs.slice(3));
+    verifyMcpCommand(parsed.unknown);
   });
 
 program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { initCommand } from './commands/init.js';
+import { detectCommand } from './commands/detect.js';
+import { syncCommand } from './commands/sync.js';
+import { applyCommand } from './commands/apply.js';
+import { verifyMcpCommand } from './commands/verifyMcp.js';
+
+const program = new Command();
+
+program
+  .name('agentinit')
+  .description('A CLI tool for managing and configuring AI coding agents')
+  .version('1.0.1');
+
+program
+  .command('apply')
+  .description('Apply configurations (MCP servers, etc.)')
+  .allowUnknownOption(true)
+  .action((...args) => {
+    // Extract raw arguments, excluding the command name
+    const rawArgs = process.argv.slice(2);
+    const applyIndex = rawArgs.indexOf('apply');
+    const configArgs = applyIndex >= 0 ? rawArgs.slice(applyIndex + 1) : [];
+    applyCommand(configArgs);
+  });
+
+program
+  .command('init')
+  .description('Initialize agents.md configuration for the current project')
+  .option('-f, --force', 'Overwrite existing configuration')
+  .option('-t, --template <template>', 'Use specific template (web, cli, library)')
+  .action(initCommand);
+
+program
+  .command('detect')
+  .description('Detect current project stack and existing agent configurations')
+  .option('-v, --verbose', 'Show detailed detection results')
+  .action(detectCommand);
+
+program
+  .command('sync')
+  .description('Sync agents.md with agent-specific configuration files')
+  .option('-d, --dry-run', 'Show what would be changed without making changes')
+  .option('-b, --backup', 'Create backup before syncing')
+  .action(syncCommand);
+
+program
+  .command('verify_mcp')
+  .description('Verify MCP server installations and list their capabilities')
+  .allowUnknownOption(true)
+  .action((...args) => {
+    // Extract raw arguments, excluding the command name
+    const rawArgs = process.argv.slice(2);
+    const verifyIndex = rawArgs.indexOf('verify_mcp');
+    const commandArgs = verifyIndex >= 0 ? rawArgs.slice(verifyIndex + 1) : [];
+    verifyMcpCommand(commandArgs);
+  });
+
+program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,61 +1,21 @@
-#!/usr/bin/env node
+/**
+ * AgentInit Library Entry Point
+ *
+ * This is the main entry point for the AgentInit library.
+ * For CLI usage, see src/cli.ts
+ *
+ * @example
+ * ```typescript
+ * import { MCPVerifier, MCPServerType } from 'agentinit';
+ *
+ * const verifier = new MCPVerifier();
+ * const result = await verifier.verifyServer({
+ *   name: 'my-server',
+ *   type: MCPServerType.STDIO,
+ *   command: 'npx',
+ *   args: ['-y', '@modelcontextprotocol/server-everything']
+ * });
+ * ```
+ */
 
-import { Command } from 'commander';
-import { initCommand } from './commands/init.js';
-import { detectCommand } from './commands/detect.js';
-import { syncCommand } from './commands/sync.js';
-import { applyCommand } from './commands/apply.js';
-import { verifyMcpCommand } from './commands/verifyMcp.js';
-
-const program = new Command();
-
-program
-  .name('agentinit')
-  .description('A CLI tool for managing and configuring AI coding agents')
-  .version('1.0.1');
-
-program
-  .command('apply')
-  .description('Apply configurations (MCP servers, etc.)')
-  .allowUnknownOption(true)
-  .action((...args) => {
-    // Extract raw arguments, excluding the command name
-    const rawArgs = process.argv.slice(2);
-    const applyIndex = rawArgs.indexOf('apply');
-    const configArgs = applyIndex >= 0 ? rawArgs.slice(applyIndex + 1) : [];
-    applyCommand(configArgs);
-  });
-
-program
-  .command('init')
-  .description('Initialize agents.md configuration for the current project')
-  .option('-f, --force', 'Overwrite existing configuration')
-  .option('-t, --template <template>', 'Use specific template (web, cli, library)')
-  .action(initCommand);
-
-program
-  .command('detect')
-  .description('Detect current project stack and existing agent configurations')
-  .option('-v, --verbose', 'Show detailed detection results')
-  .action(detectCommand);
-
-program
-  .command('sync')
-  .description('Sync agents.md with agent-specific configuration files')
-  .option('-d, --dry-run', 'Show what would be changed without making changes')
-  .option('-b, --backup', 'Create backup before syncing')
-  .action(syncCommand);
-
-program
-  .command('verify_mcp')
-  .description('Verify MCP server installations and list their capabilities')
-  .allowUnknownOption(true)
-  .action((...args) => {
-    // Extract raw arguments, excluding the command name
-    const rawArgs = process.argv.slice(2);
-    const verifyIndex = rawArgs.indexOf('verify_mcp');
-    const commandArgs = verifyIndex >= 0 ? rawArgs.slice(verifyIndex + 1) : [];
-    verifyMcpCommand(commandArgs);
-  });
-
-program.parse();
+export * from './lib/index.js';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,40 @@
+/**
+ * AgentInit Library
+ *
+ * Programmatic API for MCP (Model Context Protocol) server verification.
+ *
+ * This library allows you to verify MCP servers, calculate token usage,
+ * and work with MCP configurations programmatically.
+ *
+ * @example Basic Usage
+ * ```typescript
+ * import { MCPVerifier, MCPServerType } from 'agentinit';
+ *
+ * const verifier = new MCPVerifier();
+ * const result = await verifier.verifyServer({
+ *   name: 'my-server',
+ *   type: MCPServerType.STDIO,
+ *   command: 'npx',
+ *   args: ['-y', '@modelcontextprotocol/server-everything']
+ * });
+ *
+ * if (result.status === 'success') {
+ *   console.log(`Tools: ${result.capabilities?.tools.length}`);
+ * }
+ * ```
+ *
+ * @example Submodule Imports
+ * ```typescript
+ * // Import from specific submodules for tree-shaking
+ * import { MCPVerifier } from 'agentinit/verifier';
+ * import { MCPServerType } from 'agentinit/types';
+ * import { countTokens } from 'agentinit/utils';
+ * ```
+ *
+ * @module agentinit
+ */
+
+// Re-export everything from submodules
+export * from './verifier/index.js';
+export * from './types/index.js';
+export * from './utils/index.js';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,34 @@
+/**
+ * MCP Types Library Module
+ *
+ * This module exports all type definitions needed for working with
+ * the MCP verifier library.
+ *
+ * @example
+ * ```typescript
+ * import type { MCPServerConfig, MCPVerificationResult } from 'agentinit/types';
+ * import { MCPServerType } from 'agentinit/types';
+ *
+ * const config: MCPServerConfig = {
+ *   name: 'my-server',
+ *   type: MCPServerType.STDIO,
+ *   command: 'node',
+ *   args: ['server.js']
+ * };
+ * ```
+ */
+
+// Re-export MCP-related types and enums
+export type {
+  MCPServerConfig,
+  MCPVerificationResult,
+  MCPCapabilities,
+  MCPTool,
+  MCPResource,
+  MCPPrompt
+} from '../../types/index.js';
+
+export { MCPServerType } from '../../types/index.js';
+
+// Re-export constants
+export { DEFAULT_CONNECTION_TIMEOUT_MS } from '../../constants/index.js';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility Functions Library Module
+ *
+ * This module exports utility functions for working with MCP servers
+ * and token counting.
+ *
+ * @example
+ * ```typescript
+ * import { countTokens, MCPParser } from 'agentinit/utils';
+ *
+ * const tokens = countTokens('Hello world');
+ * const parsed = MCPParser.parseArguments(['--mcp-stdio', 'server', 'npx', 'mcp-server']);
+ * ```
+ */
+
+// Re-export token counting utility
+export { countTokens } from 'contextcalc';
+
+// Re-export MCP parser
+export { MCPParser, MCPParseError } from '../../core/mcpParser.js';
+
+// Re-export logger for library users who want consistent logging
+export { Logger, logger } from '../../utils/logger.js';

--- a/src/lib/verifier/index.ts
+++ b/src/lib/verifier/index.ts
@@ -1,0 +1,22 @@
+/**
+ * MCP Verifier Library Module
+ *
+ * This module exports the MCPVerifier class for programmatic verification
+ * of MCP (Model Context Protocol) servers.
+ *
+ * @example
+ * ```typescript
+ * import { MCPVerifier } from 'agentinit/verifier';
+ * import { MCPServerType } from 'agentinit/types';
+ *
+ * const verifier = new MCPVerifier(10000);
+ * const result = await verifier.verifyServer({
+ *   name: 'everything',
+ *   type: MCPServerType.STDIO,
+ *   command: 'npx',
+ *   args: ['-y', '@modelcontextprotocol/server-everything']
+ * });
+ * ```
+ */
+
+export { MCPVerifier, MCPVerificationError } from '../../core/mcpClient.js';

--- a/tests/lib/library-api.test.ts
+++ b/tests/lib/library-api.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { MCPVerifier, MCPVerificationError } from '../../src/lib/verifier/index.js';
+import { MCPServerType, type MCPServerConfig } from '../../src/lib/types/index.js';
+import { countTokens, MCPParser } from '../../src/lib/utils/index.js';
+
+describe('Library API - Main Entry Point', () => {
+  it('should export MCPVerifier from main entry point', async () => {
+    const { MCPVerifier: ExportedVerifier } = await import('../../src/lib/index.js');
+    expect(ExportedVerifier).toBeDefined();
+    expect(typeof ExportedVerifier).toBe('function');
+  });
+
+  it('should export MCPServerType from main entry point', async () => {
+    const { MCPServerType: ExportedServerType } = await import('../../src/lib/index.js');
+    expect(ExportedServerType).toBeDefined();
+    expect(ExportedServerType.STDIO).toBe('stdio');
+    expect(ExportedServerType.HTTP).toBe('http');
+    expect(ExportedServerType.SSE).toBe('sse');
+  });
+
+  it('should export utilities from main entry point', async () => {
+    const { countTokens: exportedCountTokens, MCPParser: ExportedParser } = await import('../../src/lib/index.js');
+    expect(exportedCountTokens).toBeDefined();
+    expect(ExportedParser).toBeDefined();
+  });
+});
+
+describe('Library API - Verifier Module', () => {
+  it('should create MCPVerifier instance', () => {
+    const verifier = new MCPVerifier();
+    expect(verifier).toBeInstanceOf(MCPVerifier);
+  });
+
+  it('should accept custom timeout', () => {
+    const verifier = new MCPVerifier(15000);
+    expect(verifier).toBeInstanceOf(MCPVerifier);
+  });
+
+  it('should have verifyServer method', () => {
+    const verifier = new MCPVerifier();
+    expect(typeof verifier.verifyServer).toBe('function');
+  });
+
+  it('should have verifyServers method', () => {
+    const verifier = new MCPVerifier();
+    expect(typeof verifier.verifyServers).toBe('function');
+  });
+
+  it('should have formatResults method', () => {
+    const verifier = new MCPVerifier();
+    expect(typeof verifier.formatResults).toBe('function');
+  });
+});
+
+describe('Library API - Types Module', () => {
+  it('should export MCPServerType enum', () => {
+    expect(MCPServerType.STDIO).toBe('stdio');
+    expect(MCPServerType.HTTP).toBe('http');
+    expect(MCPServerType.SSE).toBe('sse');
+  });
+
+  it('should allow creating MCPServerConfig objects', () => {
+    const config: MCPServerConfig = {
+      name: 'test-server',
+      type: MCPServerType.STDIO,
+      command: 'node',
+      args: ['server.js']
+    };
+
+    expect(config.name).toBe('test-server');
+    expect(config.type).toBe('stdio');
+  });
+
+  it('should allow creating HTTP server config', () => {
+    const config: MCPServerConfig = {
+      name: 'http-server',
+      type: MCPServerType.HTTP,
+      url: 'https://example.com',
+      headers: {
+        'Authorization': 'Bearer token'
+      }
+    };
+
+    expect(config.name).toBe('http-server');
+    expect(config.url).toBe('https://example.com');
+  });
+});
+
+describe('Library API - Utils Module', () => {
+  it('should export countTokens function', () => {
+    expect(typeof countTokens).toBe('function');
+  });
+
+  it('should count tokens correctly', () => {
+    const text = 'Hello world';
+    const tokens = countTokens(text);
+    expect(tokens).toBeGreaterThan(0);
+    expect(typeof tokens).toBe('number');
+  });
+
+  it('should export MCPParser', () => {
+    expect(MCPParser).toBeDefined();
+    expect(typeof MCPParser.parseArguments).toBe('function');
+  });
+
+  it('should parse STDIO MCP arguments', () => {
+    const args = ['--mcp-stdio', 'test', 'node', 'server.js'];
+    const result = MCPParser.parseArguments(args);
+
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]?.name).toBe('test');
+    expect(result.servers[0]?.type).toBe('stdio');
+    expect(result.servers[0]?.command).toBe('node');
+  });
+});
+
+describe('Library API - Error Types', () => {
+  it('should export MCPVerificationError', () => {
+    const error = new MCPVerificationError('Test error', 'test-server');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(MCPVerificationError);
+    expect(error.message).toBe('Test error');
+    expect(error.serverName).toBe('test-server');
+  });
+});
+
+describe('Library API - TypeScript Types', () => {
+  it('should have proper type inference', () => {
+    const config: MCPServerConfig = {
+      name: 'test',
+      type: MCPServerType.STDIO,
+      command: 'node',
+      args: ['server.js'],
+      env: { NODE_ENV: 'production' }
+    };
+
+    // This test passes if TypeScript compilation succeeds
+    expect(config).toBeDefined();
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Add dual CLI + library functionality to agentinit, enabling programmatic use of MCP server verification.

Features:
- New library entry point with submodule exports (verifier, types, utils)
- Separated CLI code to src/cli.ts, library exports in src/index.ts
- Added comprehensive documentation with examples to README
- Implemented tree-shakable submodule imports
- Added TypeScript declarations for all library APIs
- Created example usage in examples/library-usage.ts
- Added 17 tests for library API coverage

Changes:
- Split CLI and library code for better modularity
- Updated package.json with exports field for submodule imports
- Enhanced build process with TypeScript compilation
- Updated .gitignore to exclude compiled test files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public library API exposing verifier, types, and utilities; typed and subpath exports enabled.
  - Added a dedicated CLI entrypoint.

- Documentation
  - Comprehensive "Library API" docs with usage examples.
  - New library usage example demonstrating programmatic verification.

- Tests
  - Extensive tests covering library exports, verifier behavior, utils, errors, and typings.

- Refactor
  - Main entry switched to library-focused exports; CLI moved to its own entry.

- Chores
  - Updated .gitignore, package metadata/scripts, and added a build TypeScript config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->