### PR TITLE
feat(cli): add 'skill' alias to skills command

### DIFF
--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -66,6 +66,7 @@ export function registerSkillsCommand(program: Command): void {
   const marketplaceHelp = getMarketplaceIds().join(', ');
   const skills = program
     .command('skills')
+    .alias('skill')
     .description('Manage agent skills');
 
   // --- skills add <source> ---


### PR DESCRIPTION
Adds `.alias('skill')` to the skills command registration so that `agentinit skill add ...` works as a shorthand/typo guard for `agentinit skills add ...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shorthand alias for the skills command, allowing users to use `skill` in place of `skills`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->