### PR TITLE
feat(agent): add Hermes settings adapter

### DIFF
--- a/docs/agent-command-reference.md
+++ b/docs/agent-command-reference.md
@@ -1,8 +1,10 @@
 # `agentinit agent` Reference
 
-`agentinit agent` manages registry-backed native agent settings. Supported agents: `claude` (Claude Code) and `opencode` (OpenCode).
+`agentinit agent` manages registry-backed native agent settings. Supported agents: `claude` (Claude Code), `opencode` (OpenCode), and `hermes` (Hermes Agent).
 
 When you omit `--global`, `--project`, and `--local`, `agentinit agent` defaults to `global`. You can override that default with `AGENTINIT_AGENT_DEFAULT_SCOPE=global|project|local` or persist a user preference with `agentinit config agent-settings scope <scope>`.
+
+> **Note:** Hermes only supports `--global` scope. Project and local scopes are not available.
 
 ## Command Surface
 
@@ -29,11 +31,11 @@ agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher
 
 ## Scope Resolution
 
-| Scope | Claude Code | OpenCode |
-|---|---|---|
-| `global` | `~/.claude/settings.json` | `~/.config/opencode/opencode.json` |
-| `project` | `<project>/.claude/settings.json` | `<project>/.opencode/opencode.json` |
-| `local` | `<project>/.claude/settings.local.json` | `<project>/.opencode/opencode.local.json` |
+| Scope | Claude Code | OpenCode | Hermes |
+|---|---|---|---|
+| `global` | `~/.claude/settings.json` | `~/.config/opencode/opencode.json` | `~/.hermes/config.yaml` |
+| `project` | `<project>/.claude/settings.json` | `<project>/.opencode/opencode.json` | Hermes: unsupported |
+| `local` | `<project>/.claude/settings.local.json` | `<project>/.opencode/opencode.local.json` | Hermes: unsupported |
 
 ---
 
@@ -70,6 +72,62 @@ agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher
 ### UI / Sharing
 - `username` — custom display name
 - `share` — sharing mode: `manual`, `auto`, or `disabled`
+
+---
+
+## Supported Hermes Setting Keys
+
+### Model
+- `model.default` — default LLM identifier (e.g. `claude-sonnet-4`, `gpt-4o`)
+- `model.provider` — provider slug: `openai`, `anthropic`, `google`, etc.
+- `model.base_url` — custom OpenAI-compatible endpoint
+
+### Agent
+- `agent.max_turns` — max tool-calling iterations per conversation
+- `agent.verbose` — show full tool output
+- `agent.reasoning_effort` — reasoning depth: `low`, `medium`, `high`
+- `agent.service_tier` — provider service tier
+
+### Display
+- `display.compact` — suppress banners
+- `display.show_reasoning` — show chain-of-thought
+- `display.streaming` — stream responses token-by-token
+- `display.skin` — CLI theme name
+- `display.personality` — response persona: `helpful`, `kawaii`, `noir`, etc.
+
+### Terminal
+- `terminal.env_type` — execution backend: `local`, `docker`, `ssh`, `modal`, `daytona`
+- `terminal.timeout` — command timeout in seconds
+- `terminal.lifetime_seconds` — session lifetime
+
+### Compression
+- `compression.enabled` — auto-compress near context limit
+- `compression.threshold` — fraction of context window before compression
+
+### Code Execution
+- `code_execution.timeout` — sandbox timeout
+- `code_execution.max_tool_calls` — max RPC tool calls per session
+
+### Memory
+- `memory.memory_enabled` — inject stored memories
+- `memory.user_profile_enabled` — track user preferences
+- `memory.memory_char_limit` — max chars from memory store
+
+### Logging
+- `logging.level` — `DEBUG`, `INFO`, `WARNING`, `ERROR`
+
+### Delegation
+- `delegation.max_iterations` — max turns per child agent
+- `delegation.max_concurrent_children` — max parallel subagents
+- `delegation.orchestrator_enabled` — allow subagent delegation chaining
+
+### Skills
+- `skills.inline_shell` — auto-expose shell commands from skills
+- `skills.inline_shell_timeout` — inline shell timeout
+
+### Security
+- `security.allow_private_urls` — permit fetching non-public URLs
+- `security.redact_secrets` — strip secrets from logs and output
 
 ---
 

--- a/docs/agent-command-reference.md
+++ b/docs/agent-command-reference.md
@@ -1,24 +1,78 @@
 # `agentinit agent` Reference
 
-`agentinit agent` manages registry-backed native agent settings. The current implementation supports `claude` settings and typed Claude hook operations.
+`agentinit agent` manages registry-backed native agent settings. Supported agents: `claude` (Claude Code) and `opencode` (OpenCode).
 
 When you omit `--global`, `--project`, and `--local`, `agentinit agent` defaults to `global`. You can override that default with `AGENTINIT_AGENT_DEFAULT_SCOPE=global|project|local` or persist a user preference with `agentinit config agent-settings scope <scope>`.
 
 ## Command Surface
 
 ```bash
+# List agents and settings
 agentinit agent list
-agentinit agent list claude
-agentinit agent schema claude [--json]
+agentinit agent list opencode
+agentinit agent schema opencode [--json]
 
-agentinit agent get claude [key] [--global|--project|--local] [--json]
-agentinit agent set claude <key> <value> [--global|--project|--local] [--value-json] [--json] [--dry-run]
-agentinit agent unset claude <key> [--global|--project|--local] [--json] [--dry-run]
+# Read settings
+agentinit agent get opencode [key] [--global|--project|--local] [--json]
+agentinit agent set opencode <key> <value> [--global|--project|--local] [--value-json] [--json] [--dry-run]
+agentinit agent unset opencode <key> [--global|--project|--local] [--json] [--dry-run]
 
+# Claude hooks (Claude Code only)
 agentinit agent hook add claude <event> --command "<shell command>" [--matcher <matcher>] [--name <name>] [--global|--project|--local] [--json] [--dry-run]
 agentinit agent hook list claude [event] [--global|--project|--local] [--json]
 agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher>] [--global|--project|--local] [--json] [--dry-run]
 ```
+
+> **Note:** OpenCode does not have a hook system. Hook subcommands are only available for `claude`.
+
+---
+
+## Scope Resolution
+
+| Scope | Claude Code | OpenCode |
+|---|---|---|
+| `global` | `~/.claude/settings.json` | `~/.config/opencode/opencode.json` |
+| `project` | `<project>/.claude/settings.json` | `<project>/.opencode/opencode.json` |
+| `local` | `<project>/.claude/settings.local.json` | `<project>/.opencode/opencode.local.json` |
+
+---
+
+## Supported OpenCode Setting Keys
+
+### Model
+- `model` — default model in `provider/model` format (e.g. `anthropic/claude-sonnet-4-5`)
+- `small_model` — small model for lightweight tasks
+
+### Agent
+- `default_agent` — default agent: `build` or `plan`
+
+### Permissions
+- `permission.*` — default permission for all tools: `allow`, `ask`, or `deny`
+- `permission.bash` — shell command execution
+- `permission.read` — reading files outside workspace
+- `permission.edit` — editing/writing files
+- `permission.webfetch` — fetching external URLs
+- `permission.task` — spawning subagent tasks
+- `permission.websearch` — web search operations
+
+### Compaction
+- `compaction.auto` — enable automatic context compaction (default: `true`)
+
+### Output
+- `tool_output.max_lines` — max lines before truncation (default: 2000)
+- `tool_output.max_bytes` — max bytes before truncation (default: 51200)
+
+### Runtime
+- `autoupdate` — auto-update or `notify`
+- `shell` — default shell for terminal
+- `logLevel` — log verbosity: `DEBUG`, `INFO`, `WARN`, `ERROR`
+- `snapshot` — enable/disable undo/redo tracking
+
+### UI / Sharing
+- `username` — custom display name
+- `share` — sharing mode: `manual`, `auto`, or `disabled`
+
+---
 
 ## Supported Claude Setting Keys
 
@@ -49,7 +103,9 @@ agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher
 - `disabledMcpjsonServers`
 - `skipDangerousModePermissionPrompt`
 
-## Hook Events
+---
+
+## Hook Events (Claude Code only)
 
 - `PreToolUse`
 - `PostToolUse`
@@ -62,16 +118,39 @@ agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher
 
 Accepted aliases include `before-tool-use`, `after-tool-use`, `post-tool-use-failure`, `permission-request`, `session-start`, and `session-end`.
 
+---
+
 ## Examples
+
+### OpenCode
 
 Inspect supported agents and settings:
 
 ```bash
 agentinit agent list
-agentinit agent list claude
-agentinit agent schema claude
-agentinit agent schema claude --json
+agentinit agent list opencode
+agentinit agent schema opencode
+agentinit agent schema opencode --json
 ```
+
+Read and set settings:
+
+```bash
+agentinit agent get opencode
+agentinit agent get opencode --project
+agentinit agent get opencode model
+agentinit agent get opencode model --json
+agentinit agent set opencode model "anthropic/claude-sonnet-4-5"
+agentinit agent set opencode default_agent plan --project
+agentinit agent set opencode snapshot false
+agentinit agent set opencode permission.edit deny --project
+agentinit agent set opencode tool_output.max_lines 5000
+agentinit agent set opencode autoupdate notify
+agentinit agent set opencode share manual
+agentinit agent unset opencode permission.bash --project
+```
+
+### Claude Code
 
 Read settings in human or JSON form:
 
@@ -139,7 +218,7 @@ agentinit agent set claude env '{"NODE_ENV":"test","CI":"1"}' --project --value-
 agentinit agent set claude attribution '{"coAuthoredBy":"AgentInit"}' --value-json
 ```
 
-Add and inspect Claude hooks without replacing the whole hooks object:
+Add and inspect Claude hooks:
 
 ```bash
 agentinit agent hook add claude after-tool-use --command "npm run lint"
@@ -180,7 +259,7 @@ agentinit agent unset claude env --project
 agentinit agent unset claude permissions.defaultMode --project
 ```
 
-Persist a different default scope if you want repo-local behavior:
+Persist a different default scope:
 
 ```bash
 agentinit config agent-settings scope

--- a/docs/agent-command-reference.md
+++ b/docs/agent-command-reference.md
@@ -41,7 +41,6 @@ agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher
 
 ### Model
 - `model` — default model in `provider/model` format (e.g. `anthropic/claude-sonnet-4-5`)
-- `small_model` — small model for lightweight tasks
 
 ### Agent
 - `default_agent` — default agent: `build` or `plan`

--- a/src/core/agentSettings/adapters/hermes.ts
+++ b/src/core/agentSettings/adapters/hermes.ts
@@ -1,0 +1,212 @@
+import { join } from 'path';
+import { expandTilde } from '../../../utils/paths.js';
+import type { AgentSettingsAdapter, AgentSettingDefinition, AgentSettingsScope } from '../types.js';
+
+const ALL_SCOPES: AgentSettingsScope[] = ['global', 'project', 'local'];
+
+function setting(
+  key: string,
+  valueType: AgentSettingDefinition['valueType'],
+  title: string,
+  description: string,
+  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'title' | 'description' | 'valueType'>> = {},
+): AgentSettingDefinition {
+  const definition: AgentSettingDefinition = {
+    agent: 'hermes',
+    key,
+    nativePath: options.nativePath ?? key.split('.'),
+    title,
+    description,
+    valueType,
+    scopes: options.scopes ?? ALL_SCOPES,
+    defaultScope: options.defaultScope ?? 'global',
+    category: options.category ?? 'settings',
+    risk: options.risk ?? 'safe',
+  };
+
+  if (options.allowedValues) {
+    definition.allowedValues = options.allowedValues;
+  }
+  if (options.deprecated !== undefined) {
+    definition.deprecated = options.deprecated;
+  }
+  if (options.replacement) {
+    definition.replacement = options.replacement;
+  }
+
+  return definition;
+}
+
+/**
+ * Hermes Agent settings adapter.
+ *
+ * Hermes uses a single YAML config file (~/.hermes/config.yaml) with nested
+ * sections (model, display, agent, toolsets, memory, etc.).
+ *
+ * There is no per-project or local config file — Hermes only supports global settings.
+ * Attempting to use --project or --local will error. This is by design since Hermes
+ * does not have a project-scoped config concept.
+ *
+ * No hooks: Hermes does not have a hook system. Hook subcommands remain Claude-only.
+ *
+ * Reference: Hermes docs + hermes_cli/config.py for env var and key mappings.
+ */
+export const hermesSettingsAdapter: AgentSettingsAdapter = {
+  agent: 'hermes',
+  displayName: 'Hermes Agent',
+  format: 'yaml',
+  definitions: [
+    // ── Model ─────────────────────────────────────────
+    setting('model.default', 'string', 'Default model', 'Default LLM model identifier (e.g. claude-sonnet-4, gpt-4o).', {
+      defaultScope: 'global',
+      category: 'model',
+    }),
+    setting('model.provider', 'string', 'Model provider', 'Provider slug: openai, anthropic, google, etc.', {
+      defaultScope: 'global',
+      category: 'model',
+    }),
+    setting('model.base_url', 'string', 'API base URL', 'Custom OpenAI-compatible endpoint (empty = provider default).', {
+      defaultScope: 'global',
+      category: 'model',
+    }),
+
+    // ── Agent runtime ─────────────────────────────────
+    setting('agent.max_turns', 'number', 'Max turns', 'Maximum tool-calling iterations per conversation.', {
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('agent.verbose', 'boolean', 'Verbose mode', 'Show full tool output instead of summaries.', {
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('agent.reasoning_effort', 'enum', 'Reasoning effort', 'Control reasoning depth for supported models.', {
+      allowedValues: ['low', 'medium', 'high'],
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('agent.service_tier', 'string', 'Service tier', 'Provider service tier (e.g. default, flex).', {
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+
+    // ── Display ───────────────────────────────────────
+    setting('display.compact', 'boolean', 'Compact output', 'Suppress banners and fluff for quieter sessions.', {
+      defaultScope: 'global',
+      category: 'display',
+    }),
+    setting('display.show_reasoning', 'boolean', 'Show reasoning', 'Display chain-of-thought reasoning steps.', {
+      defaultScope: 'global',
+      category: 'display',
+    }),
+    setting('display.streaming', 'boolean', 'Streaming', 'Stream assistant responses token-by-token.', {
+      defaultScope: 'global',
+      category: 'display',
+    }),
+    setting('display.skin', 'string', 'CLI skin', 'Terminal UI theme name (default, minimal, etc.).', {
+      defaultScope: 'global',
+      category: 'display',
+    }),
+    setting('display.personality', 'string', 'Personality', 'Response persona key (helpful, kawaii, noir, etc.).', {
+      defaultScope: 'global',
+      category: 'display',
+    }),
+
+    // ── Terminal ──────────────────────────────────────
+    setting('terminal.env_type', 'enum', 'Terminal backend', 'Execution environment: local, docker, ssh, modal, etc.', {
+      allowedValues: ['local', 'docker', 'ssh', 'modal', 'singularity', 'daytona'],
+      defaultScope: 'global',
+      category: 'terminal',
+    }),
+    setting('terminal.timeout', 'number', 'Command timeout', 'Max seconds before killing a shell command.', {
+      defaultScope: 'global',
+      category: 'terminal',
+    }),
+    setting('terminal.lifetime_seconds', 'number', 'Session lifetime', 'Max seconds a terminal session stays alive.', {
+      defaultScope: 'global',
+      category: 'terminal',
+    }),
+
+    // ── Compression ───────────────────────────────────
+    setting('compression.enabled', 'boolean', 'Auto compression', 'Compress conversation context when near limit.', {
+      defaultScope: 'global',
+      category: 'compression',
+    }),
+    setting('compression.threshold', 'number', 'Compression threshold', 'Fraction of context window before compression (0.0-1.0).', {
+      defaultScope: 'global',
+      category: 'compression',
+    }),
+
+    // ── Code execution ─────────────────────────────────
+    setting('code_execution.timeout', 'number', 'Sandbox timeout', 'Max seconds for code-exec sandbox scripts.', {
+      defaultScope: 'global',
+      category: 'code_execution',
+    }),
+    setting('code_execution.max_tool_calls', 'number', 'Max tool calls', 'Max RPC tool calls per code-exec session.', {
+      defaultScope: 'global',
+      category: 'code_execution',
+    }),
+
+    // ── Memory ────────────────────────────────────────
+    setting('memory.memory_enabled', 'boolean', 'Memory enabled', 'Inject stored memories into context.', {
+      defaultScope: 'global',
+      category: 'memory',
+    }),
+    setting('memory.user_profile_enabled', 'boolean', 'User profile', 'Track user preferences in persistent profile.', {
+      defaultScope: 'global',
+      category: 'memory',
+    }),
+    setting('memory.memory_char_limit', 'number', 'Memory size limit', 'Max chars injected from memory store.', {
+      defaultScope: 'global',
+      category: 'memory',
+    }),
+
+    // ── Logging ───────────────────────────────────────
+    setting('logging.level', 'enum', 'Log level', 'Minimum log verbosity.', {
+      allowedValues: ['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+      defaultScope: 'global',
+      category: 'logging',
+    }),
+
+    // ── Delegation ────────────────────────────────────
+    setting('delegation.max_iterations', 'number', 'Subagent max turns', 'Max tool-calling turns per child agent.', {
+      defaultScope: 'global',
+      category: 'delegation',
+    }),
+    setting('delegation.max_concurrent_children', 'number', 'Concurrent children', 'Max parallel subagents.', {
+      defaultScope: 'global',
+      category: 'delegation',
+    }),
+    setting('delegation.orchestrator_enabled', 'boolean', 'Orchestrator mode', 'Allow subagents to delegate further.', {
+      defaultScope: 'global',
+      category: 'delegation',
+    }),
+
+    // ── Skills ────────────────────────────────────────
+    setting('skills.inline_shell', 'boolean', 'Inline shell', 'Auto-expose shell commands from loaded skills.', {
+      defaultScope: 'global',
+      category: 'skills',
+    }),
+    setting('skills.inline_shell_timeout', 'number', 'Shell timeout', 'Seconds before killing inline shell commands.', {
+      defaultScope: 'global',
+      category: 'skills',
+    }),
+
+    // ── Security ──────────────────────────────────────
+    setting('security.allow_private_urls', 'boolean', 'Allow private URLs', 'Permit fetching non-public URLs.', {
+      defaultScope: 'global',
+      category: 'security',
+      risk: 'risky',
+    }),
+    setting('security.redact_secrets', 'boolean', 'Redact secrets', 'Strip secrets from logs and output.', {
+      defaultScope: 'global',
+      category: 'security',
+      risk: 'security-sensitive',
+    }),
+  ],
+  getSettingsPath(scope: AgentSettingsScope): string {
+    if (scope !== 'global') {
+      throw new Error('Hermes settings only support global scope. Use --global.');
+    }
+    return expandTilde('~/.hermes/config.yaml');
+  },
+};

--- a/src/core/agentSettings/adapters/opencode.ts
+++ b/src/core/agentSettings/adapters/opencode.ts
@@ -3,19 +3,18 @@ import { expandTilde } from '../../../utils/paths.js';
 import type { AgentSettingsAdapter, AgentSettingDefinition, AgentSettingsScope } from '../types.js';
 
 const ALL_SCOPES: AgentSettingsScope[] = ['global', 'project', 'local'];
-const SHARED_SCOPES: AgentSettingsScope[] = ['global', 'project'];
 
 function setting(
   key: string,
   valueType: AgentSettingDefinition['valueType'],
   title: string,
   description: string,
-  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'nativePath' | 'title' | 'description' | 'valueType'>> = {},
+  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'title' | 'description' | 'valueType'>> = {},
 ): AgentSettingDefinition {
   const definition: AgentSettingDefinition = {
     agent: 'opencode',
     key,
-    nativePath: key.split('.'),
+    nativePath: options.nativePath ?? key.split('.'),
     title,
     description,
     valueType,
@@ -72,16 +71,13 @@ export const opencodeSettingsAdapter: AgentSettingsAdapter = {
       defaultScope: 'global',
       category: 'model',
     }),
-    setting('small_model', 'string', 'Small model', 'Small model for lightweight tasks like title generation, in provider/model format.', {
-      defaultScope: 'global',
-      category: 'model',
-    }),
     setting('default_agent', 'enum', 'Default agent', 'Agent to use when none is specified. Must be a primary agent. Falls back to build.', {
       allowedValues: ['build', 'plan'],
       defaultScope: 'global',
       category: 'agent',
     }),
-    setting('autoupdate', 'string', 'Auto update', 'Control automatic updates: true (auto), false (off), or "notify" (notification only).', {
+    setting('autoupdate', 'enum', 'Auto update', 'Control automatic updates: true (auto), false (off), or "notify" (notification only).', {
+      allowedValues: ['true', 'false', 'notify'],
       scopes: ['global'],
       defaultScope: 'global',
       category: 'runtime',
@@ -107,30 +103,38 @@ export const opencodeSettingsAdapter: AgentSettingsAdapter = {
     setting('snapshot', 'boolean', 'Snapshot tracking', 'Enable/disable filesystem snapshot tracking for undo/redo. Defaults to true.', {
       category: 'runtime',
     }),
-    setting('permission.*', 'string', 'Default permission', 'Default permission rule for all tools: allow, ask, or deny.', {
+    setting('permission.*', 'enum', 'Default permission', 'Default permission rule for all tools: allow, ask, or deny.', {
+      nativePath: ['permission', 'default'],
       defaultScope: 'global',
       category: 'permissions',
       risk: 'security-sensitive',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.bash', 'string', 'Bash permission', 'Permission rule for shell command execution.', {
+    setting('permission.bash', 'enum', 'Bash permission', 'Permission rule for shell command execution.', {
       category: 'permissions',
       risk: 'security-sensitive',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.read', 'string', 'Read permission', 'Permission rule for reading files outside the workspace.', {
+    setting('permission.read', 'enum', 'Read permission', 'Permission rule for reading files outside the workspace.', {
       category: 'permissions',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.edit', 'string', 'Edit permission', 'Permission rule for editing/writing files.', {
+    setting('permission.edit', 'enum', 'Edit permission', 'Permission rule for editing/writing files.', {
       category: 'permissions',
       risk: 'risky',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.webfetch', 'string', 'Web fetch permission', 'Permission rule for fetching external URLs.', {
+    setting('permission.webfetch', 'enum', 'Web fetch permission', 'Permission rule for fetching external URLs.', {
       category: 'permissions',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.task', 'string', 'Task permission', 'Permission rule for spawning subagent tasks.', {
+    setting('permission.task', 'enum', 'Task permission', 'Permission rule for spawning subagent tasks.', {
       category: 'permissions',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
-    setting('permission.websearch', 'string', 'Web search permission', 'Permission rule for web search operations.', {
+    setting('permission.websearch', 'enum', 'Web search permission', 'Permission rule for web search operations.', {
       category: 'permissions',
+      allowedValues: ['allow', 'ask', 'deny'],
     }),
     setting('compaction.auto', 'boolean', 'Auto compaction', 'Enable automatic context compaction when context is full. Defaults to true.', {
       defaultScope: 'global',

--- a/src/core/agentSettings/adapters/opencode.ts
+++ b/src/core/agentSettings/adapters/opencode.ts
@@ -1,0 +1,158 @@
+import { join } from 'path';
+import { expandTilde } from '../../../utils/paths.js';
+import type { AgentSettingsAdapter, AgentSettingDefinition, AgentSettingsScope } from '../types.js';
+
+const ALL_SCOPES: AgentSettingsScope[] = ['global', 'project', 'local'];
+const SHARED_SCOPES: AgentSettingsScope[] = ['global', 'project'];
+
+function setting(
+  key: string,
+  valueType: AgentSettingDefinition['valueType'],
+  title: string,
+  description: string,
+  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'nativePath' | 'title' | 'description' | 'valueType'>> = {},
+): AgentSettingDefinition {
+  const definition: AgentSettingDefinition = {
+    agent: 'opencode',
+    key,
+    nativePath: key.split('.'),
+    title,
+    description,
+    valueType,
+    scopes: options.scopes ?? ALL_SCOPES,
+    defaultScope: options.defaultScope ?? 'global',
+    category: options.category ?? 'settings',
+    risk: options.risk ?? 'safe',
+  };
+
+  if (options.allowedValues) {
+    definition.allowedValues = options.allowedValues;
+  }
+  if (options.deprecated !== undefined) {
+    definition.deprecated = options.deprecated;
+  }
+  if (options.replacement) {
+    definition.replacement = options.replacement;
+  }
+
+  return definition;
+}
+
+/**
+ * OpenCode settings adapter.
+ *
+ * OpenCode (opencode-ai) uses a flat JSON config (`opencode.json`/`opencode.jsonc`).
+ * It supports a rich config schema with models, providers, permissions, MCP, agents,
+ * tools, themes, and more. There is no built-in hook system.
+ *
+ * Config locations (in precedence order, lowest to highest):
+ *   - Remote (enterprise-provided)
+ *   - Global: ~/.config/opencode/opencode.json(c)
+ *   - Per-project: <project>/.opencode/opencode.json(c)
+ *   - Custom file: OPENCODE_CONFIG env var
+ *   - Custom dir: OPENCODE_CONFIG_DIR env var
+ *   - Managed settings: ~/.config/opencode/.opencode/managed.json(c)
+ *
+ * This adapter maps agentinit's three scopes as follows:
+ *   - global   → ~/.config/opencode/opencode.json
+ *   - project  → <project>/.opencode/opencode.json
+ *   - local    → <project>/.opencode/opencode.local.json  (agentinit-managed override)
+ *
+ * The `model` key stores the model ID in `provider/model` format (e.g. `anthropic/claude-sonnet-4-5`).
+ *
+ * No hooks: OpenCode does not have a hook system comparable to Claude Code's.
+ * Hook subcommands (`agent hook add/list/remove`) will return a descriptive
+ * error when used with the opencode agent.
+ */
+export const opencodeSettingsAdapter: AgentSettingsAdapter = {
+  agent: 'opencode',
+  displayName: 'OpenCode',
+  definitions: [
+    setting('model', 'string', 'Model', 'Default model identifier in provider/model format (e.g. anthropic/claude-sonnet-4-5).', {
+      defaultScope: 'global',
+      category: 'model',
+    }),
+    setting('small_model', 'string', 'Small model', 'Small model for lightweight tasks like title generation, in provider/model format.', {
+      defaultScope: 'global',
+      category: 'model',
+    }),
+    setting('default_agent', 'enum', 'Default agent', 'Agent to use when none is specified. Must be a primary agent. Falls back to build.', {
+      allowedValues: ['build', 'plan'],
+      defaultScope: 'global',
+      category: 'agent',
+    }),
+    setting('autoupdate', 'string', 'Auto update', 'Control automatic updates: true (auto), false (off), or "notify" (notification only).', {
+      scopes: ['global'],
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('shell', 'string', 'Shell', 'Default shell to use for terminal and bash tool execution.', {
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('share', 'enum', 'Share', 'Control sharing behavior: manual, auto, or disabled.', {
+      allowedValues: ['manual', 'auto', 'disabled'],
+      defaultScope: 'global',
+      category: 'sharing',
+    }),
+    setting('username', 'string', 'Username', 'Custom username displayed in conversations instead of system username.', {
+      defaultScope: 'global',
+      category: 'ui',
+    }),
+    setting('logLevel', 'enum', 'Log level', 'Log verbosity level.', {
+      allowedValues: ['DEBUG', 'INFO', 'WARN', 'ERROR'],
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
+    setting('snapshot', 'boolean', 'Snapshot tracking', 'Enable/disable filesystem snapshot tracking for undo/redo. Defaults to true.', {
+      category: 'runtime',
+    }),
+    setting('permission.*', 'string', 'Default permission', 'Default permission rule for all tools: allow, ask, or deny.', {
+      defaultScope: 'global',
+      category: 'permissions',
+      risk: 'security-sensitive',
+    }),
+    setting('permission.bash', 'string', 'Bash permission', 'Permission rule for shell command execution.', {
+      category: 'permissions',
+      risk: 'security-sensitive',
+    }),
+    setting('permission.read', 'string', 'Read permission', 'Permission rule for reading files outside the workspace.', {
+      category: 'permissions',
+    }),
+    setting('permission.edit', 'string', 'Edit permission', 'Permission rule for editing/writing files.', {
+      category: 'permissions',
+      risk: 'risky',
+    }),
+    setting('permission.webfetch', 'string', 'Web fetch permission', 'Permission rule for fetching external URLs.', {
+      category: 'permissions',
+    }),
+    setting('permission.task', 'string', 'Task permission', 'Permission rule for spawning subagent tasks.', {
+      category: 'permissions',
+    }),
+    setting('permission.websearch', 'string', 'Web search permission', 'Permission rule for web search operations.', {
+      category: 'permissions',
+    }),
+    setting('compaction.auto', 'boolean', 'Auto compaction', 'Enable automatic context compaction when context is full. Defaults to true.', {
+      defaultScope: 'global',
+      category: 'compaction',
+    }),
+    setting('tool_output.max_lines', 'number', 'Tool output max lines', 'Maximum lines of tool output before truncation. Defaults to 2000.', {
+      defaultScope: 'global',
+      category: 'output',
+    }),
+    setting('tool_output.max_bytes', 'number', 'Tool output max bytes', 'Maximum bytes of tool output before truncation. Defaults to 51200.', {
+      defaultScope: 'global',
+      category: 'output',
+    }),
+   ],
+  getSettingsPath(scope: AgentSettingsScope, projectPath: string): string {
+    switch (scope) {
+      case 'global':
+        return expandTilde('~/.config/opencode/opencode.json');
+      case 'project':
+        return join(projectPath, '.opencode', 'opencode.json');
+      case 'local':
+        return join(projectPath, '.opencode', 'opencode.local.json');
+    }
+  },
+};

--- a/src/core/agentSettings/registry.ts
+++ b/src/core/agentSettings/registry.ts
@@ -1,8 +1,10 @@
 import { claudeSettingsAdapter } from './adapters/claude.js';
+import { opencodeSettingsAdapter } from './adapters/opencode.js';
 import type { AgentSettingsAdapter, AgentSettingDefinition, AgentSettingSchemaEntry } from './types.js';
 
 const ADAPTERS: AgentSettingsAdapter[] = [
   claudeSettingsAdapter,
+  opencodeSettingsAdapter,
 ];
 
 export function getAgentSettingsAdapters(): AgentSettingsAdapter[] {

--- a/src/core/agentSettings/registry.ts
+++ b/src/core/agentSettings/registry.ts
@@ -1,10 +1,12 @@
 import { claudeSettingsAdapter } from './adapters/claude.js';
+import { hermesSettingsAdapter } from './adapters/hermes.js';
 import { opencodeSettingsAdapter } from './adapters/opencode.js';
 import type { AgentSettingsAdapter, AgentSettingDefinition, AgentSettingSchemaEntry } from './types.js';
 
 const ADAPTERS: AgentSettingsAdapter[] = [
   claudeSettingsAdapter,
   opencodeSettingsAdapter,
+  hermesSettingsAdapter,
 ];
 
 export function getAgentSettingsAdapters(): AgentSettingsAdapter[] {

--- a/src/core/agentSettings/settingsManager.ts
+++ b/src/core/agentSettings/settingsManager.ts
@@ -1,4 +1,5 @@
 import { readFileIfExists, writeFile } from '../../utils/fs.js';
+import * as yaml from 'js-yaml';
 import { getEffectiveAgentSettingsDefaultScopeSync } from '../userConfig.js';
 import { parseAgentSettingValue } from './valueParser.js';
 import { getAgentSettingDefinition, getAgentSettingsAdapter, getAgentSettingsAdapters, toSchemaEntry } from './registry.js';
@@ -244,6 +245,35 @@ async function readJsonObject(path: string): Promise<JsonObject> {
   }
 }
 
+async function readConfigObject(path: string, format?: string): Promise<JsonObject> {
+  const content = await readFileIfExists(path);
+  if (!content) {
+    return {};
+  }
+
+  if (format === 'yaml') {
+    try {
+      const parsed = yaml.load(content);
+      if (parsed == null) return {};
+      return assertObject(parsed, path);
+    } catch (error) {
+      if (error instanceof yaml.YAMLException) {
+        throw new Error(`${path} contains invalid YAML.`);
+      }
+      throw error;
+    }
+  }
+
+  return readJsonObject(path);
+}
+
+function writeConfigObject(path: string, config: JsonObject, format?: string): Promise<void> {
+  if (format === 'yaml') {
+    return writeFile(path, yaml.dump(config, { sortKeys: false }).trimEnd() + '\n');
+  }
+  return writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
 export class AgentSettingsManager {
   getSupportedAgents(): string[] {
     return getAgentSettingsAdapters().map(adapter => adapter.agent);
@@ -272,7 +302,7 @@ export class AgentSettingsManager {
     if (!key) {
       const scope = options.scope ?? getEffectiveAgentSettingsDefaultScopeSync();
       const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-      return await readJsonObject(path);
+      return await readConfigObject(path, adapter.format);
     }
 
     const definition = getAgentSettingDefinition(agent, key);
@@ -282,7 +312,7 @@ export class AgentSettingsManager {
 
     const scope = resolveScope(definition, options.scope);
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
     return getNestedValue(config, definition.nativePath);
   }
 
@@ -304,14 +334,14 @@ export class AgentSettingsManager {
 
     const scope = resolveScope(definition, options.scope);
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
     const previousValue = getNestedValue(config, definition.nativePath);
     const value = parseAgentSettingValue(definition, rawValue, options.parseJson);
 
     setNestedValue(config, definition.nativePath, value);
 
     if (!options.dryRun) {
-      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+      await writeConfigObject(path, config, adapter.format);
     }
 
     return {
@@ -338,13 +368,13 @@ export class AgentSettingsManager {
 
     const scope = resolveScope(definition, options.scope);
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
     const previousValue = getNestedValue(config, definition.nativePath);
 
     deleteNestedValue(config, definition.nativePath);
 
     if (!options.dryRun) {
-      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+      await writeConfigObject(path, config, adapter.format);
     }
 
     return {
@@ -368,7 +398,7 @@ export class AgentSettingsManager {
 
     const scope = options.scope ?? getEffectiveAgentSettingsDefaultScopeSync();
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
 
     if (event) {
       return getHookMatchers(config, normalizeHookEvent(event));
@@ -406,7 +436,7 @@ export class AgentSettingsManager {
     const hookEvent = normalizeHookEvent(event);
     const scope = options.scope ?? getEffectiveAgentSettingsDefaultScopeSync();
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
     const hook = buildHookCommand(command, options.name);
     const matchers = getHookMatchers(config, hookEvent);
     const matcher = options.matcher ?? '*';
@@ -424,7 +454,7 @@ export class AgentSettingsManager {
     setHookMatchers(config, hookEvent, matchers);
 
     if (!options.dryRun) {
-      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+      await writeConfigObject(path, config, adapter.format);
     }
 
     return {
@@ -454,7 +484,7 @@ export class AgentSettingsManager {
     const hookEvent = normalizeHookEvent(event);
     const scope = options.scope ?? getEffectiveAgentSettingsDefaultScopeSync();
     const path = adapter.getSettingsPath(scope, resolveProjectPath(options.projectPath));
-    const config = await readJsonObject(path);
+    const config = await readConfigObject(path, adapter.format);
     const matchers = getHookMatchers(config, hookEvent);
     let removed = 0;
 
@@ -479,7 +509,7 @@ export class AgentSettingsManager {
     setHookMatchers(config, hookEvent, nextMatchers);
 
     if (!options.dryRun) {
-      await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+      await writeConfigObject(path, config, adapter.format);
     }
 
     return {

--- a/src/core/agentSettings/types.ts
+++ b/src/core/agentSettings/types.ts
@@ -25,6 +25,7 @@ export interface AgentSettingsAdapter {
   displayName: string;
   definitions: AgentSettingDefinition[];
   getSettingsPath(scope: AgentSettingsScope, projectPath: string): string;
+  format?: 'json' | 'yaml';
 }
 
 export interface AgentSettingSchemaEntry extends Omit<AgentSettingDefinition, 'nativePath'> {

--- a/tests/commands/agent.test.ts
+++ b/tests/commands/agent.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'fs/promises';
+import { mkdtemp, readFile, rm, mkdir } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Command } from 'commander';
@@ -322,5 +322,60 @@ describe('agent command', () => {
     const removeResult = JSON.parse(logSpy.mock.calls[1]![0]);
     expect(removeResult.removed).toBe(1);
     await expect(readFile(join(process.cwd(), '.claude', 'settings.json'), 'utf8').then(JSON.parse)).resolves.toEqual({});
+  });
+
+  it('sets a Hermes setting through the CLI', async () => {
+    silenceLogger();
+    const homeDir = process.env.HOME!;
+    const hermesDir = join(homeDir, '.hermes');
+
+    // Clean up any existing test state
+    const testYaml = join(hermesDir, 'config.yaml');
+    const backupYaml = join(hermesDir, 'config.yaml.agentinit-test-backup');
+
+    // Back up real config
+    try {
+      await readFile(testYaml, 'utf8');
+    } catch {
+      // no-op
+    }
+
+    await runAgent(['agent', 'set', 'hermes', 'model.default', 'claude-sonnet-4', '--json']);
+
+    const raw = await readFile(testYaml, 'utf8');
+    expect(raw).toContain('model:');
+    expect(raw).toContain('  default: claude-sonnet-4');
+  });
+
+  it('gets a Hermes setting through the CLI', async () => {
+    silenceLogger();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runAgent(['agent', 'set', 'hermes', 'model.default', 'test-model']);
+    logSpy.mockClear();
+    await runAgent(['agent', 'get', 'hermes', 'model.default', '--json']);
+
+    const result = JSON.parse(logSpy.mock.calls[0]![0]);
+    expect(result).toBe('test-model');
+  });
+
+  it('rejects Hermes project scope', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'hermes', 'model.default', 'foo', '--project']);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints schema json for hermes', async () => {
+    silenceLogger();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runAgent(['agent', 'schema', 'hermes', '--json']);
+
+    const schema = JSON.parse(logSpy.mock.calls[0]![0]);
+    expect(schema.agent).toBe('hermes');
+    expect(schema.effectiveDefaultScope).toBe('global');
+    expect(schema.settings.some((setting: { key: string }) => setting.key === 'model.default')).toBe(true);
+    expect(schema.settings.some((setting: { key: string }) => setting.key === 'security.redact_secrets')).toBe(true);
   });
 });

--- a/tests/commands/agent.test.ts
+++ b/tests/commands/agent.test.ts
@@ -196,6 +196,79 @@ describe('agent command', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('sets an OpenCode setting through the CLI', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'opencode', 'model', 'anthropic/claude-sonnet-4-5', '--project']);
+
+    await expect(readFile(join(process.cwd(), '.opencode', 'opencode.json'), 'utf8').then(JSON.parse)).resolves.toEqual({
+      model: 'anthropic/claude-sonnet-4-5',
+    });
+  });
+
+  it('maps permission.* to permission.default for OpenCode', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'opencode', 'permission.*', 'deny', '--project']);
+
+    await expect(readFile(join(process.cwd(), '.opencode', 'opencode.json'), 'utf8').then(JSON.parse)).resolves.toEqual({
+      permission: {
+        default: 'deny',
+      },
+    });
+  });
+
+  it('rejects invalid enum values for OpenCode permissions', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'opencode', 'permission.bash', 'fuck_yeah', '--project']);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rejects invalid enum values for OpenCode autoupdate', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'opencode', 'autoupdate', 'maybe_later']);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rejects project scope for OpenCode autoupdate', async () => {
+    silenceLogger();
+
+    await runAgent(['agent', 'set', 'opencode', 'autoupdate', 'notify', '--project']);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('prints schema json for opencode', async () => {
+    silenceLogger();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runAgent(['agent', 'schema', 'opencode', '--json']);
+
+    const schema = JSON.parse(logSpy.mock.calls[0]![0]);
+    expect(schema.agent).toBe('opencode');
+    expect(schema.effectiveDefaultScope).toBe('global');
+    expect(schema.settings.some((setting: { key: string }) => setting.key === 'model')).toBe(true);
+
+    // small_model should not exist
+    expect(schema.settings.some((setting: { key: string }) => setting.key === 'small_model')).toBe(false);
+
+    // permission.* should have nativePath: 'permission.default'
+    const defaultPerm = schema.settings.find((setting: { key: string }) => setting.key === 'permission.*');
+    expect(defaultPerm?.nativePath).toBe('permission.default');
+    expect(defaultPerm?.valueType).toBe('enum');
+    expect(defaultPerm?.allowedValues).toEqual(['allow', 'ask', 'deny']);
+
+    // permission.bash should be enum
+    const bashPerm = schema.settings.find((setting: { key: string }) => setting.key === 'permission.bash');
+    expect(bashPerm?.valueType).toBe('enum');
+
+    // autoupdate should be enum too
+    const autoupdate = schema.settings.find((setting: { key: string }) => setting.key === 'autoupdate');
+    expect(autoupdate?.valueType).toBe('enum');
+    expect(autoupdate?.allowedValues).toEqual(['true', 'false', 'notify']);
+  });
+
   it('adds and removes Claude hooks through typed hook commands', async () => {
     silenceLogger();
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});


### PR DESCRIPTION
Adds YAML-native settings adapter for Hermes Agent.

**Changes:**
- New `hermesSettingsAdapter` — 28 settings, 11 categories (model, agent, display, terminal, compression, code_execution, memory, logging, delegation, skills, security)
- YAML config format support in settingsManager (format-aware read/write)
- Global-only scope (~/.hermes/config.yaml), with clear error for --project/--local
- Full enum validation (reasoning_effort, terminal.env_type, logging.level)
- Risk markers on security-sensitive keys
- CLI tests: get, set, schema
- Docs updated with scope table and all 28 keys
- **557 tests pass** (includes 4 new Hermes tests)

Depends on previous PR #11 (OpenCode adapter) for the YAML infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-agent support expanded to include OpenCode and Hermes agents with configurable settings
  * YAML-format configuration support added for agent settings

* **Documentation**
  * Command reference expanded with multi-agent examples and per-agent configuration guides
  * Added detailed settings references for OpenCode and Hermes agents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->