### PR TITLE
feat(claude): add defaultShell setting to agent settings adapter

### DIFF
--- a/docs/agent-command-reference.md
+++ b/docs/agent-command-reference.md
@@ -85,6 +85,7 @@ agentinit agent api-key status claude (--env <name>|--key <key>) [--json]
 - `attribution`
 - `includeGitInstructions`
 - `cleanupPeriodDays`
+- `defaultShell`
 - `showThinkingSummaries`
 - `spinnerTipsEnabled`
 - `autoUpdatesChannel`

--- a/src/core/agentSettings/adapters/claude.ts
+++ b/src/core/agentSettings/adapters/claude.ts
@@ -233,6 +233,11 @@ export const claudeSettingsAdapter: AgentSettingsAdapter = {
       defaultScope: 'global',
       category: 'runtime',
     }),
+    setting('defaultShell', 'enum', 'Default shell', 'Primary shell for interactive ! commands and shell blocks.', {
+      allowedValues: ['bash', 'powershell', 'zsh'],
+      defaultScope: 'global',
+      category: 'runtime',
+    }),
     setting('showThinkingSummaries', 'boolean', 'Thinking summaries', 'Show extended thinking summaries in interactive sessions.', {
       defaultScope: 'global',
       category: 'ui',


### PR DESCRIPTION
Add a `defaultShell` enum setting to the Claude Code settings adapter, supporting `bash`, `powershell`, and `zsh`.

**Usage:**
```bash
agentinit agent set claude defaultShell powershell
```

Maps to the native `defaultShell` key in Claude Code's `settings.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Default Shell** setting that allows users to select their preferred shell (bash, powershell, or zsh) for interactive commands and shell blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->