### PR TITLE
feat(codex): add default_mode_request_user_input setting

### DIFF
--- a/docs/agent-command-reference.md
+++ b/docs/agent-command-reference.md
@@ -1,0 +1,421 @@
+# `agentinit agent` Reference
+
+`agentinit agent` manages registry-backed native agent settings. The current implementation supports `claude`, `codex`, and `opencode` settings, plus typed hook operations for agents that expose native hooks.
+
+When you omit `--global`, `--project`, and `--local`, `agentinit agent` defaults to `global`. You can override that default with `AGENTINIT_AGENT_DEFAULT_SCOPE=global|project|local` or persist a user preference with `agentinit config agent-settings scope <scope>`. Individual agents may support only a subset of scopes; Codex and OpenCode support `--global` and `--project`.
+
+## Command Surface
+
+```bash
+agentinit agent list
+agentinit agent list claude [--global|--project|--local] [--json] [--details]
+agentinit agent list codex [--global|--project] [--json] [--details]
+agentinit agent list opencode [--global|--project] [--json] [--details]
+agentinit agent schema claude [--json]
+agentinit agent schema codex [--json]
+agentinit agent schema opencode [--json]
+
+agentinit agent get claude [key] [--global|--project|--local] [--json]
+agentinit agent set claude <key> <value> [--global|--project|--local] [--value-json] [--json] [--dry-run]
+agentinit agent unset claude <key> [--global|--project|--local] [--json] [--dry-run]
+agentinit agent get codex [key] [--global|--project] [--json]
+agentinit agent set codex <key> <value> [--global|--project] [--value-json] [--json] [--dry-run]
+agentinit agent unset codex <key> [--global|--project] [--json] [--dry-run]
+agentinit agent get opencode [key] [--global|--project] [--json]
+agentinit agent set opencode <key> <value> [--global|--project] [--value-json] [--json] [--dry-run]
+agentinit agent unset opencode <key> [--global|--project] [--json] [--dry-run]
+
+agentinit agent hook add claude <event> --command "<shell command>" [--matcher <matcher>] [--name <name>] [--global|--project|--local] [--json] [--dry-run]
+agentinit agent hook list claude [event] [--global|--project|--local] [--json]
+agentinit agent hook remove claude <event> <command-or-name> [--matcher <matcher>] [--global|--project|--local] [--json] [--dry-run]
+agentinit agent hook add codex <event> --command "<shell command>" [--matcher <matcher>] [--name <name>] [--global|--project] [--json] [--dry-run]
+agentinit agent hook list codex [event] [--global|--project] [--json]
+agentinit agent hook remove codex <event> <command-or-name> [--matcher <matcher>] [--global|--project] [--json] [--dry-run]
+
+agentinit agent api-key approve claude (--env <name>|--key <key>) [--json] [--dry-run]
+agentinit agent api-key reject claude (--env <name>|--key <key>) [--json] [--dry-run]
+agentinit agent api-key forget claude (--env <name>|--key <key>) [--json] [--dry-run]
+agentinit agent api-key status claude (--env <name>|--key <key>) [--json]
+```
+
+## Supported Claude Setting Keys
+
+- `theme`
+- `editorMode`
+- `verbose`
+- `preferredNotifChannel`
+- `autoCompactEnabled`
+- `fileCheckpointingEnabled`
+- `showTurnDuration`
+- `terminalProgressBarEnabled`
+- `todoFeatureEnabled`
+- `teammateMode`
+- `autoConnectIde`
+- `autoInstallIdeExtension`
+- `diffTool`
+- `respectGitignore`
+- `copyFullResponse`
+- `copyOnSelect`
+- `remoteControlAtStartup`
+- `taskCompleteNotifEnabled`
+- `inputNeededNotifEnabled`
+- `agentPushNotifEnabled`
+- `showStatusInTerminalTab`
+- `prStatusFooterEnabled`
+- `claudeInChromeDefaultEnabled`
+- `teammateDefaultModel`
+- `model`
+- `agent`
+- `env`
+- `permissions.allow`
+- `permissions.deny`
+- `permissions.ask`
+- `permissions.defaultMode`
+- `permissions.disableBypassPermissionsMode`
+- `permissions.additionalDirectories`
+- `worktree.symlinkDirectories`
+- `worktree.sparsePaths`
+- `plansDirectory`
+- `autoMemoryDirectory`
+- `autoMemoryEnabled`
+- `autoDreamEnabled`
+- `alwaysThinkingEnabled`
+- `effortLevel`
+- `prefersReducedMotion`
+- `attribution`
+- `includeGitInstructions`
+- `cleanupPeriodDays`
+- `showThinkingSummaries`
+- `spinnerTipsEnabled`
+- `autoUpdatesChannel`
+- `language`
+- `outputStyle`
+- `defaultView`
+- `useAutoModeDuringPlan`
+- `includeCoAuthoredBy`
+- `enableAllProjectMcpServers`
+- `enabledMcpjsonServers`
+- `disabledMcpjsonServers`
+- `skipDangerousModePermissionPrompt`
+
+## Supported Codex Setting Keys
+
+Codex settings are written to `~/.codex/config.toml` for `--global` and `.codex/config.toml` for `--project`.
+
+- `model`
+- `model_provider`
+- `model_reasoning_effort`
+- `approval_policy`
+- `sandbox_mode`
+- `web_search`
+- `notify`
+- `instructions`
+- `model_instructions_file`
+- `features.apps`
+- `features.codex_hooks`
+- `features.fast_mode`
+- `features.goals`
+- `features.memories`
+- `features.multi_agent`
+- `features.personality`
+- `features.shell_snapshot`
+- `features.shell_tool`
+- `features.unified_exec`
+- `features.undo`
+- `features.web_search`
+- `features.web_search_cached`
+- `features.web_search_request`
+
+## Supported OpenCode Setting Keys
+
+OpenCode settings are written to `~/.config/opencode/opencode.json` for `--global` and `.opencode/opencode.json` for `--project`. If the matching `opencode.jsonc` already exists, AgentInit updates that file instead; existing global `config.json` is also respected for older OpenCode installs. OpenCode does not have a native AgentInit `--local` settings scope.
+
+- `model`
+- `small_model`
+- `provider`
+- `default_agent`
+- `autoupdate`
+- `shell`
+- `share`
+- `username`
+- `logLevel`
+- `snapshot`
+- `permission.*`
+- `permission.bash`
+- `permission.read`
+- `permission.edit`
+- `permission.webfetch`
+- `permission.task`
+- `permission.websearch`
+- `compaction.auto`
+- `tool_output.max_lines`
+- `tool_output.max_bytes`
+
+## Hook Events
+
+- `PreToolUse`
+- `PostToolUse`
+- `PostToolUseFailure`
+- `Notification`
+- `PermissionRequest`
+- `Stop`
+- `SessionStart`
+- `SessionEnd`
+
+Accepted aliases include `before-tool-use`, `after-tool-use`, `post-tool-use-failure`, `permission-request`, `session-start`, and `session-end`.
+
+Codex supports `PreToolUse`, `PermissionRequest`, `PostToolUse`, `SessionStart`, `UserPromptSubmit`, and `Stop`. Accepted Codex aliases include `pre-tool-use`, `post-tool-use`, `permission-request`, `session-start`, and `user-prompt-submit`. OpenCode does not expose a native hook system through `agentinit agent hook`.
+
+## Examples
+
+Inspect supported agents and settings:
+
+```bash
+agentinit agent list
+agentinit agent list claude
+agentinit agent list codex
+agentinit agent list opencode
+agentinit agent schema claude
+agentinit agent schema codex
+agentinit agent schema opencode
+agentinit agent schema claude --json
+agentinit agent schema codex --json
+agentinit agent schema opencode --json
+```
+
+`agent schema <agent>` is the reference view: it shows the registered schema,
+types, categories, descriptions, risks, and supported scopes without reading the
+current settings files. `agent list <agent>` is the browsable state view: it
+shows the same descriptions plus safe current-value summaries for the selected
+scope. Unsupported agent scopes are rejected; settings outside a supported
+selected scope are shown as not applicable. `agent get <agent> [key]` prints
+exact raw values.
+
+For compatibility, `agent list <agent> --json` still returns only the supported
+key array. Use `agent list <agent> --details --json` for detailed metadata and
+safe current-state summaries.
+
+Read settings in human or JSON form:
+
+```bash
+agentinit agent get claude
+agentinit agent get claude --project
+agentinit agent get claude model
+agentinit agent get claude model --json
+agentinit agent get claude env --project --json
+agentinit agent get claude permissions.allow --project --json
+agentinit agent get codex
+agentinit agent get codex --project
+agentinit agent get codex features.codex_hooks
+agentinit agent get codex web_search --json
+agentinit agent get opencode
+agentinit agent get opencode --project
+agentinit agent get opencode model
+agentinit agent get opencode permission.* --project --json
+```
+
+Global full reads include regular `~/.claude/settings.json` values plus registered AgentInit-managed `~/.claude.json` settings. Internal Claude global config state such as `projects`, auth records, caches, and usage counters is not exposed.
+
+Set string values:
+
+```bash
+agentinit agent set claude model sonnet
+agentinit agent set claude agent reviewer --project
+agentinit agent set claude plansDirectory .claude/plans --project
+agentinit agent set claude language spanish
+agentinit agent set claude outputStyle concise
+agentinit agent set claude teammateDefaultModel sonnet
+agentinit agent set codex model gpt-5.4
+agentinit agent set codex model_provider openai
+agentinit agent set codex model_instructions_file AGENTS.md --project
+agentinit agent set opencode model anthropic/claude-sonnet-4-5
+agentinit agent set opencode small_model anthropic/claude-haiku-4-5
+agentinit agent set opencode default_agent my_custom --project
+agentinit agent set opencode shell zsh
+```
+
+Set booleans:
+
+```bash
+agentinit agent set claude verbose true
+agentinit agent set claude autoCompactEnabled on
+agentinit agent set claude fileCheckpointingEnabled true
+agentinit agent set claude showTurnDuration false
+agentinit agent set claude terminalProgressBarEnabled true
+agentinit agent set claude todoFeatureEnabled true
+agentinit agent set claude autoConnectIde false
+agentinit agent set claude autoInstallIdeExtension true
+agentinit agent set claude respectGitignore true
+agentinit agent set claude copyFullResponse false
+agentinit agent set claude copyOnSelect true
+agentinit agent set claude remoteControlAtStartup true
+agentinit agent set claude taskCompleteNotifEnabled true
+agentinit agent set claude inputNeededNotifEnabled true
+agentinit agent set claude agentPushNotifEnabled false
+agentinit agent set claude showStatusInTerminalTab true
+agentinit agent set claude prStatusFooterEnabled true
+agentinit agent set claude claudeInChromeDefaultEnabled true
+agentinit agent set claude alwaysThinkingEnabled on
+agentinit agent set claude autoMemoryEnabled true
+agentinit agent set claude autoDreamEnabled false
+agentinit agent set claude prefersReducedMotion true
+agentinit agent set claude includeGitInstructions false
+agentinit agent set claude showThinkingSummaries yes
+agentinit agent set claude spinnerTipsEnabled off
+agentinit agent set claude enableAllProjectMcpServers true --project
+agentinit agent set claude skipDangerousModePermissionPrompt true
+agentinit agent set claude useAutoModeDuringPlan true --local
+agentinit agent set codex features.apps false
+agentinit agent set codex features.codex_hooks true
+agentinit agent set codex features.fast_mode true
+agentinit agent set codex features.memories false
+agentinit agent set codex features.multi_agent true
+agentinit agent set codex features.personality true
+agentinit agent set codex features.shell_snapshot true
+agentinit agent set codex features.shell_tool true
+agentinit agent set codex features.unified_exec true
+agentinit agent set codex features.undo false
+agentinit agent set opencode autoupdate false
+agentinit agent set opencode snapshot true --project
+agentinit agent set opencode compaction.auto true
+```
+
+Set enums:
+
+```bash
+agentinit agent set claude theme dark
+agentinit agent set claude editorMode vim
+agentinit agent set claude preferredNotifChannel terminal_bell
+agentinit agent set claude teammateMode auto
+agentinit agent set claude diffTool auto
+agentinit agent set claude effortLevel high
+agentinit agent set claude permissions.defaultMode acceptEdits --project
+agentinit agent set claude permissions.defaultMode dontAsk --local
+agentinit agent set claude permissions.disableBypassPermissionsMode disable
+agentinit agent set claude autoUpdatesChannel stable
+agentinit agent set claude defaultView chat --local
+agentinit agent set codex model_reasoning_effort high
+agentinit agent set codex default_mode_request_user_input true
+agentinit agent set codex approval_policy on-request --project
+agentinit agent set codex sandbox_mode workspace-write --project
+agentinit agent set codex web_search live
+agentinit agent set opencode share manual
+agentinit agent set opencode logLevel INFO
+agentinit agent set opencode autoupdate notify
+agentinit agent set opencode permission.* ask --project
+agentinit agent set opencode permission.bash allow --project
+agentinit agent set opencode permission.edit deny --project
+```
+
+Set numbers:
+
+```bash
+agentinit agent set claude cleanupPeriodDays 30
+agentinit agent set opencode tool_output.max_lines 5000
+agentinit agent set opencode tool_output.max_bytes 100000
+```
+
+Set arrays:
+
+```bash
+agentinit agent set claude permissions.allow 'Bash(npm test *)' --project
+agentinit agent set claude permissions.deny 'Bash(rm -rf *)' --project
+agentinit agent set claude permissions.ask 'Bash(git push *)' --project
+agentinit agent set claude permissions.additionalDirectories '["../shared","../docs"]' --project --value-json
+agentinit agent set claude worktree.symlinkDirectories '["node_modules",".env.local"]' --project --value-json
+agentinit agent set claude worktree.sparsePaths '["src","tests","package.json"]' --project --value-json
+agentinit agent set claude enabledMcpjsonServers '["github","playwright"]' --project --value-json
+agentinit agent set claude disabledMcpjsonServers '["dangerous-server"]' --project --value-json
+agentinit agent set codex notify '["terminal-notifier","-message","Codex finished"]' --value-json
+```
+
+Set objects:
+
+```bash
+agentinit agent set claude env '{"AGENTINIT_TEST":"1"}' --value-json
+agentinit agent set claude env '{"NODE_ENV":"test","CI":"1"}' --project --value-json
+agentinit agent set claude attribution '{"coAuthoredBy":"AgentInit"}' --value-json
+agentinit agent set opencode provider '{"local-llm":{"name":"Local LLM","npm":"@ai-sdk/openai-compatible","options":{"baseURL":"http://localhost:11434/v1","apiKey":"{env:LOCAL_LLM_API_KEY}"},"models":{"llama-3":{"name":"Llama 3","tool_call":true}}}}' --project --value-json
+```
+
+OpenCode provider configuration can contain API keys. Prefer OpenCode's `{env:NAME}` substitution instead of writing raw secrets into config files.
+
+Add and inspect Claude hooks without replacing the whole hooks object:
+
+```bash
+agentinit agent hook add claude after-tool-use --command "npm run lint"
+agentinit agent hook add claude after-tool-use --command "npm run lint" --matcher "Edit|Write" --name lint-after-edit
+agentinit agent hook add claude after-tool-use --command "npm test" --matcher "Edit|Write" --name test-after-edit --project
+agentinit agent hook add claude pre-tool-use --command "echo about to run tool" --matcher "Bash" --project
+agentinit agent hook list claude
+agentinit agent hook list claude --project
+agentinit agent hook list claude post-tool-use
+agentinit agent hook list claude post-tool-use --json
+agentinit agent hook remove claude post-tool-use lint-after-edit --matcher "Edit|Write"
+agentinit agent hook remove claude post-tool-use test-after-edit --matcher "Edit|Write" --project
+agentinit agent hook remove claude post-tool-use "npm run lint"
+```
+
+Add and inspect Codex hooks in `config.toml`:
+
+```bash
+agentinit agent set codex features.codex_hooks true
+agentinit agent hook add codex pre-tool-use --command "npm run lint" --matcher "^Bash$" --project
+agentinit agent hook add codex post-tool-use --command "npm test" --matcher "^Bash$" --name test-after-bash --project
+agentinit agent hook add codex user-prompt-submit --command "scripts/check-prompt.sh" --project
+agentinit agent hook list codex --project
+agentinit agent hook list codex pre-tool-use --project --json
+agentinit agent hook remove codex post-tool-use test-after-bash --matcher "^Bash$" --project
+```
+
+Manage Claude custom API key trust responses:
+
+```bash
+agentinit agent api-key approve claude --env ANTHROPIC_API_KEY
+agentinit agent api-key status claude --env ANTHROPIC_API_KEY --json
+agentinit agent api-key reject claude --key sk-ant-...
+agentinit agent api-key forget claude --env ANTHROPIC_API_KEY
+```
+
+The raw API key is never written to `~/.claude.json` by these commands. AgentInit stores and prints only Claude's normalized last-20-character fingerprint. Prefer `--env`; `--key` is supported for convenience but can expose the raw key in shell history and process listings, and the CLI warns on human-readable runs.
+
+Preview writes without changing files:
+
+```bash
+agentinit agent set claude effortLevel high --dry-run
+agentinit agent unset claude includeGitInstructions --dry-run
+agentinit agent hook add claude after-tool-use --command "npm test" --project --dry-run
+agentinit agent hook add codex pre-tool-use --command "npm test" --project --dry-run
+agentinit agent api-key approve claude --env ANTHROPIC_API_KEY --dry-run
+```
+
+Machine-readable output:
+
+```bash
+agentinit agent set claude model sonnet --json
+agentinit agent get claude model --json
+agentinit agent unset claude effortLevel --json
+agentinit agent hook list claude post-tool-use --project --json
+agentinit agent hook list codex pre-tool-use --project --json
+agentinit agent api-key status claude --env ANTHROPIC_API_KEY --json
+```
+
+Remove settings:
+
+```bash
+agentinit agent unset claude effortLevel
+agentinit agent unset claude env --project
+agentinit agent unset claude permissions.defaultMode --project
+agentinit agent unset claude remoteControlAtStartup
+agentinit agent unset claude defaultView --local
+```
+
+Persist a different default scope if you want repo-local behavior:
+
+```bash
+agentinit config agent-settings scope
+agentinit config agent-settings scope project
+agentinit config agent-settings clear-scope
+```
+
+Use `--value-json` when the value itself is JSON. Use `--json` when the command output should be machine-readable.

--- a/src/core/agentSettings/adapters/codex.ts
+++ b/src/core/agentSettings/adapters/codex.ts
@@ -1,0 +1,142 @@
+import { join } from 'path';
+import { expandTilde } from '../../../utils/paths.js';
+import type { AgentHookEvent, AgentSettingsAdapter, AgentSettingDefinition, AgentSettingsScope } from '../types.js';
+
+const ALL_SCOPES: AgentSettingsScope[] = ['global', 'project'];
+const CODEX_HOOK_EVENTS: AgentHookEvent[] = [
+  'PreToolUse',
+  'PermissionRequest',
+  'PostToolUse',
+  'SessionStart',
+  'UserPromptSubmit',
+  'Stop',
+];
+
+function setting(
+  key: string,
+  valueType: AgentSettingDefinition['valueType'],
+  title: string,
+  description: string,
+  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'nativePath' | 'title' | 'description' | 'valueType'>> = {},
+): AgentSettingDefinition {
+  const definition: AgentSettingDefinition = {
+    agent: 'codex',
+    key,
+    nativePath: key.split('.'),
+    title,
+    description,
+    valueType,
+    scopes: options.scopes ?? ALL_SCOPES,
+    defaultScope: options.defaultScope ?? 'global',
+    category: options.category ?? 'settings',
+    risk: options.risk ?? 'safe',
+  };
+
+  if (options.allowedValues) {
+    definition.allowedValues = options.allowedValues;
+  }
+  if (options.deprecated !== undefined) {
+    definition.deprecated = options.deprecated;
+  }
+  if (options.replacement) {
+    definition.replacement = options.replacement;
+  }
+
+  return definition;
+}
+
+function featureSetting(
+  key: string,
+  title: string,
+  description: string,
+  options: Partial<Omit<AgentSettingDefinition, 'agent' | 'key' | 'nativePath' | 'title' | 'description' | 'valueType' | 'category'>> = {},
+): AgentSettingDefinition {
+  return setting(`features.${key}`, 'boolean', title, description, {
+    ...options,
+    category: 'features',
+  });
+}
+
+export const codexSettingsAdapter: AgentSettingsAdapter = {
+  agent: 'codex',
+  displayName: 'OpenAI Codex CLI',
+  format: 'toml',
+  hookEvents: CODEX_HOOK_EVENTS,
+  hookScopes: ALL_SCOPES,
+  definitions: [
+    setting('model', 'string', 'Model', 'Override the default Codex model.', {
+      category: 'model',
+    }),
+    setting('model_provider', 'string', 'Model provider', 'Select a configured model provider.', {
+      category: 'model',
+    }),
+    setting('model_reasoning_effort', 'enum', 'Reasoning effort', 'Reasoning effort for supported models.', {
+      allowedValues: ['minimal', 'low', 'medium', 'high'],
+      category: 'model',
+    }),
+    setting('approval_policy', 'enum', 'Approval policy', 'Control when Codex asks for approval before running commands.', {
+      allowedValues: ['untrusted', 'on-failure', 'on-request', 'never'],
+      category: 'permissions',
+      risk: 'security-sensitive',
+    }),
+    setting('sandbox_mode', 'enum', 'Sandbox mode', 'Control Codex command sandboxing.', {
+      allowedValues: ['read-only', 'workspace-write', 'danger-full-access'],
+      category: 'permissions',
+      risk: 'security-sensitive',
+    }),
+    setting('web_search', 'enum', 'Web search', 'Top-level Codex web search mode.', {
+      allowedValues: ['live', 'cached', 'disabled'],
+      category: 'tools',
+    }),
+    setting('notify', 'array', 'Notifications', 'Program arguments for a notification command run after agent turns.', {
+      category: 'notifications',
+    }),
+    setting('instructions', 'string', 'Instructions', 'Additional user instructions for Codex.', {
+      category: 'runtime',
+    }),
+    setting('default_mode_request_user_input', 'boolean', 'Default mode: request user input', 'When true, Codex enters a mode that asks the user for input before proceeding with actions.', {
+      category: 'runtime',
+    }),
+    setting('model_instructions_file', 'string', 'Model instructions file', 'Path to a model instructions file for Codex.', {
+      category: 'runtime',
+    }),
+    featureSetting('apps', 'Apps', 'Enable ChatGPT Apps/connectors support.', {
+      risk: 'risky',
+    }),
+    featureSetting('codex_hooks', 'Codex hooks', 'Enable lifecycle hooks from hooks.json or inline [hooks].'),
+    featureSetting('fast_mode', 'Fast mode', 'Enable Fast mode selection and the service_tier = "fast" path.'),
+    featureSetting('goals', 'Goals', 'Enable the goals feature.'),
+    featureSetting('memories', 'Memories', 'Enable Codex Memories.'),
+    featureSetting('multi_agent', 'Multi-agent', 'Enable subagent collaboration tools.'),
+    featureSetting('personality', 'Personality', 'Enable personality selection controls.'),
+    featureSetting('shell_snapshot', 'Shell snapshot', 'Snapshot your shell environment to speed up repeated commands.'),
+    featureSetting('shell_tool', 'Shell tool', 'Enable the default shell tool.'),
+    featureSetting('unified_exec', 'Unified exec', 'Use the unified PTY-backed exec tool.'),
+    featureSetting('undo', 'Undo', 'Enable undo via per-turn git ghost snapshots.'),
+    featureSetting('web_search', 'Legacy web search feature', 'Deprecated legacy web search feature toggle; prefer top-level web_search.', {
+      risk: 'deprecated',
+      deprecated: true,
+      replacement: 'web_search',
+    }),
+    featureSetting('web_search_cached', 'Legacy cached web search', 'Deprecated legacy toggle that maps to web_search = "cached" when unset.', {
+      risk: 'deprecated',
+      deprecated: true,
+      replacement: 'web_search',
+    }),
+    featureSetting('web_search_request', 'Legacy live web search', 'Deprecated legacy toggle that maps to web_search = "live" when unset.', {
+      risk: 'deprecated',
+      deprecated: true,
+      replacement: 'web_search',
+    }),
+  ],
+  getSettingsPath(scope: AgentSettingsScope, projectPath: string): string {
+    switch (scope) {
+      case 'global':
+        return expandTilde('~/.codex/config.toml');
+      case 'project':
+        return join(projectPath, '.codex', 'config.toml');
+      case 'local':
+        return join(projectPath, '.codex', 'config.toml');
+    }
+  },
+};

--- a/tests/core/agentSettings/settingsManager.test.ts
+++ b/tests/core/agentSettings/settingsManager.test.ts
@@ -1,0 +1,700 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as TOML from '@iarna/toml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentSettingsManager } from '../../../src/core/agentSettings/settingsManager.js';
+import { writeUserConfig } from '../../../src/core/userConfig.js';
+
+describe('AgentSettingsManager', () => {
+  const tempDirs: string[] = [];
+  const originalHome = process.env.HOME;
+  const originalAgentSettingsScope = process.env.AGENTINIT_AGENT_DEFAULT_SCOPE;
+  let projectPath: string;
+
+  beforeEach(async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'agentinit-agent-home-'));
+    projectPath = await mkdtemp(join(tmpdir(), 'agentinit-agent-project-'));
+    tempDirs.push(homeDir, projectPath);
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalAgentSettingsScope === undefined) {
+      delete process.env.AGENTINIT_AGENT_DEFAULT_SCOPE;
+    } else {
+      process.env.AGENTINIT_AGENT_DEFAULT_SCOPE = originalAgentSettingsScope;
+    }
+
+    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function readProjectSettings() {
+    return JSON.parse(await readFile(join(projectPath, '.claude', 'settings.json'), 'utf8'));
+  }
+
+  async function readGlobalSettings() {
+    return JSON.parse(await readFile(join(process.env.HOME!, '.claude', 'settings.json'), 'utf8'));
+  }
+
+  async function readClaudeGlobalConfig() {
+    return JSON.parse(await readFile(join(process.env.HOME!, '.claude.json'), 'utf8'));
+  }
+
+  async function readCodexGlobalSettings() {
+    return TOML.parse(await readFile(join(process.env.HOME!, '.codex', 'config.toml'), 'utf8'));
+  }
+
+  async function readCodexProjectSettings() {
+    return TOML.parse(await readFile(join(projectPath, '.codex', 'config.toml'), 'utf8'));
+  }
+
+  it('sets nested Claude settings in global scope by default', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('claude', 'permissions.defaultMode', 'acceptEdits', { projectPath });
+
+    await expect(readGlobalSettings()).resolves.toEqual({
+      permissions: {
+        defaultMode: 'acceptEdits',
+      },
+    });
+  });
+
+  it('sets Codex TOML settings and feature flags', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('codex', 'model_reasoning_effort', 'high', { projectPath });
+    await manager.set('codex', 'web_search', 'live', { projectPath });
+    await manager.set('codex', 'features.codex_hooks', 'true', { projectPath });
+    await manager.set('codex', 'default_mode_request_user_input', 'true', { projectPath });
+
+    await expect(readCodexGlobalSettings()).resolves.toMatchObject({
+      model_reasoning_effort: 'high',
+      web_search: 'live',
+      features: {
+        codex_hooks: true,
+      },
+      default_mode_request_user_input: true,
+    });
+  });
+
+  it('writes Codex project TOML settings when requested', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('codex', 'sandbox_mode', 'workspace-write', {
+      projectPath,
+      scope: 'project',
+    });
+
+    await expect(readCodexProjectSettings()).resolves.toMatchObject({
+      sandbox_mode: 'workspace-write',
+    });
+  });
+
+  it('writes Codex model instructions file with the native config key', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('codex', 'model_instructions_file', 'AGENTS.md', { projectPath });
+
+    await expect(readCodexGlobalSettings()).resolves.toMatchObject({
+      model_instructions_file: 'AGENTS.md',
+    });
+  });
+
+  it('rejects unsupported Codex local full settings reads', async () => {
+    const manager = new AgentSettingsManager();
+
+    await expect(manager.get('codex', undefined, {
+      projectPath,
+      scope: 'local',
+    })).rejects.toThrow('codex settings do not support local scope');
+  });
+
+  it('parses booleans, enums, arrays, and objects', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('claude', 'alwaysThinkingEnabled', 'on', { projectPath });
+    await manager.set('claude', 'effortLevel', 'high', { projectPath });
+    await manager.set('claude', 'permissions.allow', 'Bash(npm run test *)', { projectPath });
+    await manager.set('claude', 'env', '{"AGENTINIT_TEST":"1"}', {
+      projectPath,
+      parseJson: true,
+    });
+
+    await expect(readGlobalSettings()).resolves.toMatchObject({
+      alwaysThinkingEnabled: true,
+      effortLevel: 'high',
+      permissions: {
+        allow: ['Bash(npm run test *)'],
+      },
+      env: {
+        AGENTINIT_TEST: '1',
+      },
+    });
+  });
+
+  it('respects configured and environment default scopes when no explicit scope is provided', async () => {
+    const manager = new AgentSettingsManager();
+
+    await writeUserConfig({
+      defaultAgentSettingsScope: 'project',
+      customMarketplaces: [],
+      verifiedGithubRepos: [],
+    });
+    await manager.set('claude', 'model', 'sonnet', { projectPath });
+    await expect(readProjectSettings()).resolves.toEqual({
+      model: 'sonnet',
+    });
+
+    process.env.AGENTINIT_AGENT_DEFAULT_SCOPE = 'local';
+    await manager.set('claude', 'effortLevel', 'high', { projectPath });
+    await expect(readFile(join(projectPath, '.claude', 'settings.local.json'), 'utf8').then(JSON.parse)).resolves.toEqual({
+      effortLevel: 'high',
+    });
+  });
+
+  it('writes global Claude config settings to ~/.claude.json and preserves unrelated state', async () => {
+    const manager = new AgentSettingsManager();
+    const globalConfigPath = join(process.env.HOME!, '.claude.json');
+    await writeFile(globalConfigPath, JSON.stringify({
+      projects: {
+        '/project': {
+          lastSessionId: 'session-1',
+        },
+      },
+      cachedGrowthBookFeatures: {
+        feature: true,
+      },
+      customApiKeyResponses: {
+        approved: ['last-20-characters'],
+        rejected: [],
+      },
+    }, null, 2));
+
+    await manager.set('claude', 'theme', 'dark', { projectPath });
+    await manager.set('claude', 'preferredNotifChannel', 'terminal_bell', { projectPath });
+    await manager.set('claude', 'taskCompleteNotifEnabled', 'true', { projectPath });
+
+    await expect(readClaudeGlobalConfig()).resolves.toEqual({
+      projects: {
+        '/project': {
+          lastSessionId: 'session-1',
+        },
+      },
+      cachedGrowthBookFeatures: {
+        feature: true,
+      },
+      customApiKeyResponses: {
+        approved: ['last-20-characters'],
+        rejected: [],
+      },
+      theme: 'dark',
+      preferredNotifChannel: 'terminal_bell',
+      taskCompleteNotifEnabled: true,
+    });
+  });
+
+  it('uses global scope for global-config settings when the default scope is project', async () => {
+    const manager = new AgentSettingsManager();
+
+    await writeUserConfig({
+      defaultAgentSettingsScope: 'project',
+      customMarketplaces: [],
+      verifiedGithubRepos: [],
+    });
+
+    await manager.set('claude', 'editorMode', 'vim', { projectPath });
+
+    await expect(readClaudeGlobalConfig()).resolves.toEqual({
+      editorMode: 'vim',
+    });
+    await expect(readProjectSettings()).rejects.toThrow();
+  });
+
+  it('does not fall back to global for non-global-config settings when the default scope is unsupported', async () => {
+    const manager = new AgentSettingsManager();
+
+    await writeUserConfig({
+      defaultAgentSettingsScope: 'project',
+      customMarketplaces: [],
+      verifiedGithubRepos: [],
+    });
+
+    await expect(manager.set('claude', 'skipDangerousModePermissionPrompt', 'true', { projectPath }))
+      .rejects.toThrow('does not support project scope');
+    await expect(readGlobalSettings()).rejects.toThrow();
+  });
+
+  it('includes registered global config values in full global reads without exposing internal Claude state', async () => {
+    const manager = new AgentSettingsManager();
+    const globalConfigPath = join(process.env.HOME!, '.claude.json');
+    await manager.set('claude', 'model', 'sonnet', { projectPath });
+    await writeFile(globalConfigPath, JSON.stringify({
+      theme: 'dark',
+      projects: {
+        '/project': {
+          lastSessionId: 'session-1',
+        },
+      },
+      primaryApiKey: 'secret',
+    }, null, 2));
+
+    await expect(manager.get('claude', undefined, { scope: 'global', projectPath })).resolves.toEqual({
+      model: 'sonnet',
+      theme: 'dark',
+    });
+  });
+
+  it('exposes the effective default scope in the schema', async () => {
+    const manager = new AgentSettingsManager();
+
+    expect(manager.getSchema('claude').effectiveDefaultScope).toBe('global');
+
+    await writeUserConfig({
+      defaultAgentSettingsScope: 'project',
+      customMarketplaces: [],
+      verifiedGithubRepos: [],
+    });
+    expect(manager.getSchema('claude').effectiveDefaultScope).toBe('project');
+
+    process.env.AGENTINIT_AGENT_DEFAULT_SCOPE = 'local';
+    expect(manager.getSchema('claude').effectiveDefaultScope).toBe('local');
+  });
+
+  it('rejects unsupported scopes for personal risky settings', async () => {
+    const manager = new AgentSettingsManager();
+
+    await expect(
+      manager.set('claude', 'theme', 'dark', {
+        projectPath,
+        scope: 'project',
+      }),
+    ).rejects.toThrow('does not support project scope');
+
+    await expect(
+      manager.set('claude', 'useAutoModeDuringPlan', 'true', {
+        projectPath,
+        scope: 'project',
+      }),
+    ).rejects.toThrow('does not support project scope');
+
+    await expect(
+      manager.set('claude', 'skipDangerousModePermissionPrompt', 'true', {
+        projectPath,
+        scope: 'project',
+      }),
+    ).rejects.toThrow('does not support project scope');
+  });
+
+  it('unsets nested values and removes empty parent objects', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.set('claude', 'permissions.defaultMode', 'plan', { projectPath });
+    await manager.unset('claude', 'permissions.defaultMode', { projectPath });
+
+    await expect(readGlobalSettings()).resolves.toEqual({});
+  });
+
+  it('does not write when dry-run is enabled', async () => {
+    const manager = new AgentSettingsManager();
+
+    const result = await manager.set('claude', 'model', 'opus[1m]', {
+      projectPath,
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    await expect(readGlobalSettings()).rejects.toThrow();
+  });
+
+  it('rejects raw command-executing and managed Claude settings', async () => {
+    const manager = new AgentSettingsManager();
+
+    await expect(manager.set('claude', 'hooks', '{"PreToolUse":[]}', { projectPath, parseJson: true }))
+      .rejects.toThrow('Unknown claude setting: hooks');
+    await expect(manager.set('claude', 'sandbox', '{"enabled":true}', { projectPath, parseJson: true }))
+      .rejects.toThrow('Unknown claude setting: sandbox');
+    await expect(manager.set('claude', 'statusLine', '{"type":"command","command":"whoami"}', { projectPath, parseJson: true }))
+      .rejects.toThrow('Unknown claude setting: statusLine');
+    await expect(manager.set('claude', 'enabledPlugins', '{"plugin":true}', { projectPath, parseJson: true }))
+      .rejects.toThrow('Unknown claude setting: enabledPlugins');
+  });
+
+  it('manages custom API key trust responses without exposing raw settings', async () => {
+    const manager = new AgentSettingsManager();
+    const globalConfigPath = join(process.env.HOME!, '.claude.json');
+    await writeFile(globalConfigPath, JSON.stringify({
+      projects: {
+        '/project': {
+          lastSessionId: 'session-1',
+        },
+      },
+      customApiKeyResponses: {
+        approved: [],
+        rejected: ['56789012345678901234'],
+      },
+    }, null, 2));
+
+    await expect(manager.getApiKeyStatus('claude', 'sk-ant-12345678901234567890', { projectPath })).resolves.toMatchObject({
+      fingerprint: '12345678901234567890',
+      status: 'unknown',
+    });
+
+    await expect(manager.updateApiKeyTrust('claude', 'approve', 'sk-ant-12345678901234567890', { projectPath })).resolves.toMatchObject({
+      fingerprint: '12345678901234567890',
+      previousStatus: 'unknown',
+      status: 'approved',
+    });
+    await expect(manager.updateApiKeyTrust('claude', 'reject', 'sk-ant-12345678901234567890', { projectPath })).resolves.toMatchObject({
+      previousStatus: 'approved',
+      status: 'rejected',
+    });
+    await expect(manager.updateApiKeyTrust('claude', 'forget', 'sk-ant-12345678901234567890', { projectPath })).resolves.toMatchObject({
+      previousStatus: 'rejected',
+      status: 'unknown',
+    });
+
+    await expect(readClaudeGlobalConfig()).resolves.toEqual({
+      projects: {
+        '/project': {
+          lastSessionId: 'session-1',
+        },
+      },
+      customApiKeyResponses: {
+        approved: [],
+        rejected: ['56789012345678901234'],
+      },
+    });
+  });
+
+  it('moves API key fingerprints between approval lists and rejects malformed existing trust state', async () => {
+    const manager = new AgentSettingsManager();
+    const globalConfigPath = join(process.env.HOME!, '.claude.json');
+    await writeFile(globalConfigPath, JSON.stringify({
+      customApiKeyResponses: {
+        approved: [],
+        rejected: ['12345678901234567890'],
+      },
+    }, null, 2));
+
+    await manager.updateApiKeyTrust('claude', 'approve', 'sk-ant-12345678901234567890', { projectPath });
+    await expect(readClaudeGlobalConfig()).resolves.toEqual({
+      customApiKeyResponses: {
+        approved: ['12345678901234567890'],
+        rejected: [],
+      },
+    });
+
+    await manager.updateApiKeyTrust('claude', 'reject', 'sk-ant-12345678901234567890', { projectPath });
+    await expect(readClaudeGlobalConfig()).resolves.toEqual({
+      customApiKeyResponses: {
+        approved: [],
+        rejected: ['12345678901234567890'],
+      },
+    });
+
+    await writeFile(globalConfigPath, JSON.stringify({
+      customApiKeyResponses: {
+        approved: '12345678901234567890',
+        rejected: [],
+      },
+    }, null, 2));
+
+    await expect(manager.updateApiKeyTrust('claude', 'approve', 'sk-ant-12345678901234567890', { projectPath }))
+      .rejects.toThrow('customApiKeyResponses.approved value must be an array of strings');
+  });
+
+  it('adds, lists, and removes typed Claude command hooks', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.addHook('claude', 'after-tool-use', 'npm run lint', {
+      projectPath,
+      matcher: 'Edit|Write',
+      name: 'lint-after-edit',
+    });
+
+    await expect(readGlobalSettings()).resolves.toEqual({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit|Write',
+            hooks: [
+              {
+                type: 'command',
+                command: 'npm run lint',
+                name: 'lint-after-edit',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await expect(manager.listHooks('claude', 'post-tool-use', { projectPath })).resolves.toEqual([
+      {
+        matcher: 'Edit|Write',
+        hooks: [
+          {
+            type: 'command',
+            command: 'npm run lint',
+            name: 'lint-after-edit',
+          },
+        ],
+      },
+    ]);
+
+    await manager.removeHook('claude', 'PostToolUse', 'lint-after-edit', { projectPath, matcher: 'Edit|Write' });
+
+    await expect(readGlobalSettings()).resolves.toEqual({});
+  });
+
+  it('adds, lists, and removes typed Codex command hooks in TOML config', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.addHook('codex', 'pre-tool-use', 'npm run lint', {
+      projectPath,
+      scope: 'project',
+      matcher: '^Bash$',
+      name: 'lint-before-bash',
+    });
+
+    await expect(readCodexProjectSettings()).resolves.toMatchObject({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: '^Bash$',
+            hooks: [
+              {
+                type: 'command',
+                command: 'npm run lint',
+                name: 'lint-before-bash',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    await expect(manager.listHooks('codex', 'PreToolUse', {
+      projectPath,
+      scope: 'project',
+    })).resolves.toEqual([
+      {
+        matcher: '^Bash$',
+        hooks: [
+          {
+            type: 'command',
+            command: 'npm run lint',
+            name: 'lint-before-bash',
+          },
+        ],
+      },
+    ]);
+
+    await manager.removeHook('codex', 'pre-tool-use', 'lint-before-bash', {
+      projectPath,
+      scope: 'project',
+      matcher: '^Bash$',
+    });
+
+    await expect(readCodexProjectSettings()).resolves.not.toHaveProperty('hooks');
+  });
+
+  it('rejects unsupported hook events for Codex', async () => {
+    const manager = new AgentSettingsManager();
+
+    await expect(manager.addHook('codex', 'SessionEnd', 'echo done', { projectPath }))
+      .rejects.toThrow('does not support SessionEnd hooks');
+    await expect(manager.addHook('codex', 'pre-tool-use', 'echo done', {
+      projectPath,
+      scope: 'local',
+    })).rejects.toThrow('hooks do not support local scope');
+  });
+
+  it('preserves unrelated hooks when adding and removing hooks', async () => {
+    const manager = new AgentSettingsManager();
+
+    await manager.addHook('claude', 'pre-tool-use', 'echo pre', { projectPath, matcher: 'Bash' });
+    await manager.addHook('claude', 'post-tool-use', 'echo post', { projectPath });
+    await manager.removeHook('claude', 'post-tool-use', 'echo post', { projectPath });
+
+    await expect(readGlobalSettings()).resolves.toEqual({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash',
+            hooks: [
+              {
+                type: 'command',
+                command: 'echo pre',
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('preserves unknown hook fields while appending new hooks', async () => {
+    const manager = new AgentSettingsManager();
+    const settingsPath = join(process.env.HOME!, '.claude', 'settings.json');
+    await mkdir(join(process.env.HOME!, '.claude'), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit',
+            customMatcherField: true,
+            hooks: [
+              {
+                type: 'command',
+                command: 'echo existing',
+                timeout: 1000,
+              },
+            ],
+          },
+        ],
+      },
+    }, null, 2));
+
+    await manager.addHook('claude', 'post-tool-use', 'echo next', { projectPath, matcher: 'Edit' });
+
+    await expect(readGlobalSettings()).resolves.toEqual({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit',
+            customMatcherField: true,
+            hooks: [
+              {
+                type: 'command',
+                command: 'echo existing',
+                timeout: 1000,
+              },
+              {
+                type: 'command',
+                command: 'echo next',
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('preserves existing non-command hook types while adding and removing command hooks', async () => {
+    const manager = new AgentSettingsManager();
+    const settingsPath = join(process.env.HOME!, '.claude', 'settings.json');
+    await mkdir(join(process.env.HOME!, '.claude'), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit',
+            hooks: [
+              {
+                type: 'prompt',
+                prompt: 'Summarize the changes before continuing.',
+              },
+              {
+                type: 'command',
+                command: 'echo existing',
+                name: 'existing-command',
+              },
+            ],
+          },
+        ],
+      },
+    }, null, 2));
+
+    await expect(manager.listHooks('claude', 'post-tool-use', { projectPath })).resolves.toEqual([
+      {
+        matcher: 'Edit',
+        hooks: [
+          {
+            type: 'prompt',
+            prompt: 'Summarize the changes before continuing.',
+          },
+          {
+            type: 'command',
+            command: 'echo existing',
+            name: 'existing-command',
+          },
+        ],
+      },
+    ]);
+
+    await manager.addHook('claude', 'post-tool-use', 'echo next', { projectPath, matcher: 'Edit' });
+    await manager.removeHook('claude', 'post-tool-use', 'existing-command', { projectPath, matcher: 'Edit' });
+
+    await expect(readGlobalSettings()).resolves.toEqual({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: 'Edit',
+            hooks: [
+              {
+                type: 'prompt',
+                prompt: 'Summarize the changes before continuing.',
+              },
+              {
+                type: 'command',
+                command: 'echo next',
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('rejects dangerous permission modes and object values without explicit JSON parsing', async () => {
+    const manager = new AgentSettingsManager();
+
+    await expect(manager.set('claude', 'permissions.defaultMode', 'bypassPermissions', { projectPath }))
+      .rejects.toThrow('must be one of: default, acceptEdits, plan, dontAsk');
+    await expect(manager.set('claude', 'env', '{"AGENTINIT_TEST":"1"}', { projectPath }))
+      .rejects.toThrow('Use --value-json');
+  });
+
+  it('exposes the Claude schema without raw command-executing or managed settings', () => {
+    const manager = new AgentSettingsManager();
+    const schema = manager.getSchema('claude');
+    const keys = schema.settings.map(setting => setting.key);
+
+    expect(keys).toContain('model');
+    expect(keys).toContain('theme');
+    expect(keys).toContain('taskCompleteNotifEnabled');
+    expect(keys).toContain('teammateDefaultModel');
+    expect(keys).toContain('env');
+    expect(keys).toContain('alwaysThinkingEnabled');
+    expect(keys).toContain('autoMemoryEnabled');
+    expect(keys).toContain('autoDreamEnabled');
+    expect(keys).toContain('skipDangerousModePermissionPrompt');
+    expect(schema.settings.find(setting => setting.key === 'theme')).toMatchObject({
+      store: 'globalConfig',
+      scopes: ['global'],
+    });
+    expect(schema.settings.find(setting => setting.key === 'useAutoModeDuringPlan')).toMatchObject({
+      scopes: ['global', 'local'],
+    });
+    expect(keys).not.toContain('hooks');
+    expect(keys).not.toContain('sandbox');
+    expect(keys).not.toContain('statusLine');
+    expect(keys).not.toContain('customApiKeyResponses');
+    expect(keys).not.toContain('primaryApiKey');
+    expect(keys).not.toContain('projects');
+    expect(keys).not.toContain('enabledPlugins');
+    expect(keys).not.toContain('extraKnownMarketplaces');
+    expect(keys).not.toContain('allowedMcpServers');
+    expect(keys).not.toContain('deniedMcpServers');
+  });
+});


### PR DESCRIPTION
This PR adds the `default_mode_request_user_input` boolean setting to the Codex settings adapter.

## Problem
Currently, `agentinit agent set codex default_mode_request_user_input true` fails with:
```
Unknown codex setting: default_mode_request_user_input
```

This setting is a documented Codex CLI runtime option (under `[default]` in `~/.codex/config.toml`) but was missing from agentinit's settings registry.

## Changes
- Added `default_mode_request_user_input` definition to `src/core/agentSettings/adapters/codex.ts` (`boolean`, `runtime` category)
- Added test assertion to verify the setting can be set and read back from TOML config
- Updated docs with a usage example

## Usage
```bash
agentinit agent set codex default_mode_request_user_input true
```

This enables Codex to enter a mode that requests explicit user input before proceeding with actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive reference guide for the `agentinit agent` command, including usage examples, supported settings and hooks, API key management, and default scope behavior.

* **New Features**
  * Added support for configuring Codex agent settings with persistent storage and scope management across global and project levels.

* **Tests**
  * Added extensive test coverage for settings management including default scope behavior, configuration persistence, API key trust handling, and hook validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentinit/agentinit/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->